### PR TITLE
Feat/28 auth context

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ ext {
 
 dependencies {
     implementation "com.pagely:common:1.0.2"
+    // AOP 편의 어노테이션 개발
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     // jjwt - gateway와 동일한 버전의 jjwt 사용
     implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
     runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"

--- a/src/main/java/com/pagely/userservice/infrastructure/config/UserContextAuditorAware.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/config/UserContextAuditorAware.java
@@ -1,5 +1,6 @@
 package com.pagely.userservice.infrastructure.config;
 
+import com.pagely.userservice.infrastructure.security.UserContextHolder;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -16,14 +17,6 @@ public class UserContextAuditorAware implements AuditorAware<UUID> {
     @Override
     public Optional<UUID> getCurrentAuditor() {
         // Filter에서 이미 가공해둔 UserContextHolder(또는 UserContext)를 참조합니다.
-        UUID userId = null; // TODO: 임시 구현
-        // UUID userId = UserContext.getUserId();
-
-        if (userId == null) {
-            // 회원가입 등 인증 정보가 없는 경우
-            return Optional.empty();
-        }
-
-        return Optional.of(userId);
+        return UserContextHolder.findCurrentUserId();
     }
 }

--- a/src/main/java/com/pagely/userservice/infrastructure/config/WebConfig.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/config/WebConfig.java
@@ -1,0 +1,27 @@
+package com.pagely.userservice.infrastructure.config;
+
+import com.pagely.userservice.infrastructure.security.CurrentUserIdResolver;
+import com.pagely.userservice.infrastructure.security.CurrentUserRoleResolver;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Spring MVC 설정.
+ *
+ * <p>커스텀 ArgumentResolver 등록:
+ * <ul>
+ *   <li>{@link CurrentUserIdResolver}</li>
+ *   <li>{@link CurrentUserRoleResolver}</li>
+ * </ul>
+ */
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new CurrentUserIdResolver());
+        resolvers.add(new CurrentUserRoleResolver());
+    }
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/security/AuthAspect.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/security/AuthAspect.java
@@ -1,0 +1,52 @@
+package com.pagely.userservice.infrastructure.security;
+
+import com.pagely.common.exception.BusinessException;
+import com.pagely.common.exception.CommonErrorCode;
+import com.pagely.userservice.domain.model.Role;
+import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link AuthRequired} 어노테이션 처리 Aspect.
+ *
+ * <p>메서드 호출 전 UserContextHolder 검사:
+ * <ul>
+ *   <li>인증 정보 부재 → 401 UNAUTHORIZED</li>
+ *   <li>role 미일치 → 403 FORBIDDEN</li>
+ *   <li>통과 → 메서드 진행</li>
+ * </ul>
+ */
+@Slf4j
+@Aspect
+@Component
+public class AuthAspect {
+
+    @Around("@annotation(authRequired)")
+    public Object checkAuth(ProceedingJoinPoint pjp, AuthRequired authRequired) throws Throwable {
+        // 1. 인증 검사
+        if (!UserContextHolder.isAuthenticated()) {
+            log.debug("인증 거부: 미인증 상태에서 보호 메서드 호출 — {}",
+                    pjp.getSignature().toShortString());
+            throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
+        }
+
+        // 2. 권한 검사
+        Role[] requiredRoles = authRequired.role();
+        if (requiredRoles.length > 0) {
+            Role currentRole = UserContextHolder.getCurrentRoleOrThrow();
+            if (!Arrays.asList(requiredRoles).contains(currentRole)) {
+                log.warn("권한 거부: role={}, required={}, method={}",
+                        currentRole, Arrays.toString(requiredRoles),
+                        pjp.getSignature().toShortString());
+                throw new BusinessException(CommonErrorCode.FORBIDDEN);
+            }
+        }
+
+        // 3. 통과
+        return pjp.proceed();
+    }
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/security/AuthContextFilter.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/security/AuthContextFilter.java
@@ -1,0 +1,70 @@
+package com.pagely.userservice.infrastructure.security;
+
+import com.pagely.userservice.domain.model.Role;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Gateway가 주입한 인증 헤더를 UserContextHolder에 전파.
+ *
+ * <p><b>처리 흐름</b></p>
+ * <ol>
+ *   <li>X-User-Id, X-User-Role 헤더 추출</li>
+ *   <li>둘 다 있으면 UserContextHolder.set()</li>
+ *   <li>finally 에서 UserContextHolder.clear() — 스레드 풀 누수 방지</li>
+ * </ol>
+ *
+ */
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 100)
+public class AuthContextFilter extends OncePerRequestFilter {
+
+    private static final String HEADER_USER_ID = "X-User-Id";
+    private static final String HEADER_USER_ROLE = "X-User-Role";
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain chain
+    ) throws ServletException, IOException {
+
+        try {
+            populateContext(request);
+            chain.doFilter(request, response);
+        } finally {
+            UserContextHolder.clear();
+        }
+    }
+
+    private void populateContext(HttpServletRequest request) {
+        String userIdHeader = request.getHeader(HEADER_USER_ID);
+        String roleHeader = request.getHeader(HEADER_USER_ROLE);
+
+        if (userIdHeader == null || roleHeader == null) {
+            log.trace("인증 헤더 부재 — 미인증 요청으로 처리: path={}", request.getRequestURI());
+            return;
+        }
+
+        try {
+            UUID userId = UUID.fromString(userIdHeader);
+            Role role = Role.valueOf(roleHeader);
+            UserContextHolder.set(UserContext.of(userId, role));
+            log.debug("인증 컨텍스트 설정: userId={}, role={}", userId, role);
+        } catch (IllegalArgumentException e) {
+            // 헤더 값 형식 잘못 — 로그만 남기고 미인증으로 처리
+            log.warn("인증 헤더 형식 오류 — 무시: userIdHeader={}, roleHeader={}",
+                    userIdHeader, roleHeader);
+        }
+    }
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/security/AuthRequired.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/security/AuthRequired.java
@@ -35,8 +35,8 @@ import java.lang.annotation.Target;
  *
  * @see AuthAspect
  */
-@Target(ElementType.METHOD) // 어노테이션을 어디에 붙일 수 있는지 제한 (메서드에만)
-@Retention(RetentionPolicy.RUNTIME) //
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
 public @interface AuthRequired {
 
     /**

--- a/src/main/java/com/pagely/userservice/infrastructure/security/AuthRequired.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/security/AuthRequired.java
@@ -1,0 +1,46 @@
+package com.pagely.userservice.infrastructure.security;
+
+import com.pagely.userservice.domain.model.Role;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 메서드 호출 전 인증/권한 검사를 강제하는 어노테이션.
+ *
+ * <p><b>사용 예</b></p>
+ * <pre>{@code
+ * // 인증만 필수, role 무관
+ * @AuthRequired
+ * @GetMapping("/me")
+ * public UserResponse getMyInfo() { ... }
+ *
+ * // 특정 role 만 허용
+ * @AuthRequired(role = Role.MASTER)
+ * @DeleteMapping("/users/{id}")
+ * public void deleteUser(@PathVariable UUID id) { ... }
+ *
+ * // 여러 role 허용
+ * @AuthRequired(role = {Role.MASTER, Role.CREATOR})
+ * @PostMapping("/admin/...")
+ * public void adminTask() { ... }
+ * }</pre>
+ *
+ * <p><b>동작</b></p>
+ * <ul>
+ *   <li>UserContextHolder 에 인증 정보가 없으면 BusinessException(UNAUTHORIZED) → 401</li>
+ *   <li>role 지정 시 현재 role 이 허용 목록에 없으면 BusinessException(FORBIDDEN) → 403</li>
+ * </ul>
+ *
+ * @see AuthAspect
+ */
+@Target(ElementType.METHOD) // 어노테이션을 어디에 붙일 수 있는지 제한 (메서드에만)
+@Retention(RetentionPolicy.RUNTIME) //
+public @interface AuthRequired {
+
+    /**
+     * 허용할 role. 빈 배열 = 인증만 검사 (role 무관).
+     */
+    Role[] role() default {};
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/security/CurrentUserId.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/security/CurrentUserId.java
@@ -1,0 +1,27 @@
+package com.pagely.userservice.infrastructure.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 컨트롤러 메서드 파라미터에 현재 인증된 유저의 ID 를 자동 주입.
+ *
+ * <p><b>사용 예</b></p>
+ * <pre>{@code
+ * @GetMapping("/me")
+ * public UserResponse getMyInfo(@CurrentUserId UUID userId) {
+ *     return userService.findById(userId);
+ * }
+ * }</pre>
+ *
+ * <p>UserContextHolder 에 인증 정보가 없으면 BusinessException(UNAUTHORIZED).
+ *
+ * @AuthRequired 와 함께 쓰면 AOP 가 먼저 차단하여 더 명확.</p>
+ * @see CurrentUserIdResolver
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUserId {
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/security/CurrentUserIdResolver.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/security/CurrentUserIdResolver.java
@@ -1,0 +1,30 @@
+package com.pagely.userservice.infrastructure.security;
+
+import java.util.UUID;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * {@link CurrentUserId} 어노테이션 파라미터에 UserContextHolder 의 userId 주입.
+ */
+public class CurrentUserIdResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUserId.class)
+                && UUID.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        return UserContextHolder.getCurrentUserIdOrThrow();
+    }
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/security/CurrentUserRole.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/security/CurrentUserRole.java
@@ -1,0 +1,16 @@
+package com.pagely.userservice.infrastructure.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 컨트롤러 메서드 파라미터에 현재 인증된 유저의 Role 을 자동 주입.
+ *
+ * @see CurrentUserRoleResolver
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUserRole {
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/security/CurrentUserRoleResolver.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/security/CurrentUserRoleResolver.java
@@ -1,0 +1,30 @@
+package com.pagely.userservice.infrastructure.security;
+
+import com.pagely.userservice.domain.model.Role;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * {@link CurrentUserRole} 어노테이션 파라미터에 UserContextHolder 의 role 주입.
+ */
+public class CurrentUserRoleResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUserRole.class)
+                && Role.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        return UserContextHolder.getCurrentRoleOrThrow();
+    }
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/security/UserContext.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/security/UserContext.java
@@ -1,0 +1,26 @@
+package com.pagely.userservice.infrastructure.security;
+
+import com.pagely.userservice.domain.model.Role;
+import java.util.UUID;
+
+/**
+ * 현재 요청을 처리 중인 인증된 유저의 컨텍스트 정보.
+ * <p>
+ * Gateway 가 주입한 헤더(X-User-Id, X-User-Role)에서 추출.
+ * </p>
+ */
+public record UserContext(
+        UUID userId,
+        Role role
+) {
+
+    public static UserContext of(UUID userId, Role role) {
+        if (userId == null) {
+            throw new IllegalArgumentException("userId 는 null 일 수 없습니다.");
+        }
+        if (role == null) {
+            throw new IllegalArgumentException("role 은 null 일 수 없습니다.");
+        }
+        return new UserContext(userId, role);
+    }
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/security/UserContextHolder.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/security/UserContextHolder.java
@@ -1,0 +1,92 @@
+package com.pagely.userservice.infrastructure.security;
+
+import com.pagely.common.exception.BusinessException;
+import com.pagely.common.exception.CommonErrorCode;
+import com.pagely.userservice.domain.model.Role;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * ThreadLocal 기반 인증 컨텍스트 홀더.
+ *
+ * <p>Gateway 가 주입한 인증 정보를 요청 처리 중 어디서든 접근 가능.
+ * AuthContextFilter 가 요청 시작 시 set, 응답 후 clear.</p>
+ *
+ * <p><b>주의</b></p>
+ * <ul>
+ *   <li>호출 가능 영역: HTTP 요청 처리 스레드 내부 (필터/컨트롤러/서비스)</li>
+ *   <li>cleanup 누락 시 스레드 풀 환경에서 권한 누수 발생 가능 (예: 다른 사용자의 정보가 보임)</li>
+ * </ul>
+ */
+public final class UserContextHolder {
+
+    private static final ThreadLocal<UserContext> CONTEXT = new ThreadLocal<>();
+
+    private UserContextHolder() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    // ── set / clear ────────────────────────────────────────────────────
+
+    public static void set(UserContext context) {
+        CONTEXT.set(context);
+    }
+
+    public static void clear() {
+        CONTEXT.remove();
+    }
+
+    // ── UserContext ──────────────────────────────────────────────────
+
+    public static UserContext get() {
+        return CONTEXT.get();
+    }
+
+    public static Optional<UserContext> find() {
+        return Optional.ofNullable(CONTEXT.get());
+    }
+
+    public static UserContext getOrThrow() {
+        UserContext context = CONTEXT.get();
+        if (context == null) {
+            throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
+        }
+        return context;
+    }
+
+    // ── userId ─────────────────────────────────────────────────────────
+
+    public static UUID getCurrentUserId() {
+        UserContext context = CONTEXT.get();
+        return context == null ? null : context.userId();
+    }
+
+    public static Optional<UUID> findCurrentUserId() {
+        return find().map(UserContext::userId);
+    }
+
+    public static UUID getCurrentUserIdOrThrow() {
+        return getOrThrow().userId();
+    }
+
+    // ── role ───────────────────────────────────────────────────────────
+
+    public static Role getCurrentRole() {
+        UserContext context = CONTEXT.get();
+        return context == null ? null : context.role();
+    }
+
+    public static Optional<Role> findCurrentRole() {
+        return find().map(UserContext::role);
+    }
+
+    public static Role getCurrentRoleOrThrow() {
+        return getOrThrow().role();
+    }
+
+    // ── 인증 여부 ──────────────────────────────────────────────────────
+
+    public static boolean isAuthenticated() {
+        return CONTEXT.get() != null;
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- Gateway 가 주입한 X-User-Id, X-User-Role 헤더를 ThreadLocal 에 저장하여 
서비스 레이어 어디서든 UserContextHolder 로 현재 요청의 인증 정보 접근 가능하게 구현
- JPA Auditing 의 createdBy/updatedBy 자동 채움
- 편의 어노테이션 `@RequireAuth`, `@CurrentUserId`, `@CurrentUserRole` 구현
- 먼저 userService에 만들고, 나중에 pagely-common 으로 옮겨서 다른 서비스도 동일 활용

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #28  \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #28 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
```java
@GetMapping("/me/_debug")
    @AuthRequired
    public ResponseEntity<ApiResponse> debugMe(
            @CurrentUserId UUID userId,
            @CurrentUserRole Role role
    ) {
        return ApiResponse.ok(Map.of(
                "userId", userId.toString(),
                "role", role.name()
        ));
    }
```
<img width="1094" height="972" alt="image" src="https://github.com/user-attachments/assets/d0093520-ef2f-4ef5-86a2-796743a16bcb" />
<img width="1928" height="900" alt="image" src="https://github.com/user-attachments/assets/0ce8efa3-d47f-436e-93ce-7cba7f4fdf2c" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * HTTP 헤더 기반 요청 인증 및 권한 검증 시스템 추가
  * 컨트롤러 메서드에서 현재 사용자 ID와 역할 정보 자동 주입
  * 메서드 수준 접근 제어를 위한 애노테이션 기반 AOP 시스템 도입

<!-- end of auto-generated comment: release notes by coderabbit.ai -->