### PR TITLE
Feat/39 User 정보 조회 (api + internal)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,11 @@ ext {
 
 dependencies {
     implementation "com.pagely:common:2.0.0"
+    // QueryDSL (core는 common에서 전파, jpa+apt만 추가)
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
     // jjwt - gateway와 동일한 버전의 jjwt 사용
     implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
     runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"

--- a/src/main/java/com/pagely/userservice/application/dto/command/LoginCommand.java
+++ b/src/main/java/com/pagely/userservice/application/dto/command/LoginCommand.java
@@ -1,4 +1,4 @@
-package com.pagely.userservice.application.dto;
+package com.pagely.userservice.application.dto.command;
 
 public record LoginCommand(
         String loginId,

--- a/src/main/java/com/pagely/userservice/application/dto/command/SignupCommand.java
+++ b/src/main/java/com/pagely/userservice/application/dto/command/SignupCommand.java
@@ -1,4 +1,4 @@
-package com.pagely.userservice.application.dto;
+package com.pagely.userservice.application.dto.command;
 
 import com.pagely.userservice.domain.model.Gender;
 import java.time.LocalDate;

--- a/src/main/java/com/pagely/userservice/application/dto/query/UserSearchCondition.java
+++ b/src/main/java/com/pagely/userservice/application/dto/query/UserSearchCondition.java
@@ -1,0 +1,40 @@
+package com.pagely.userservice.application.dto.query;
+
+import com.pagely.common.auth.Role;
+import com.pagely.userservice.domain.model.Gender;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 검색 조건 DTO. Controller 쿼리 파라미터에서 자동 바인딩됨.
+ * <p>
+ * ex) GET /api/v1/users?keyword=홍&role=CREATOR&isSuspended=false
+ */
+@Getter
+@Setter
+public class UserSearchCondition {
+
+    private List<UUID> ids; // MSA 내부 서비스에서 조회
+    private String loginId;
+    private String name;
+    private String email;
+    private String nickname;
+    private Role role;
+    private Gender gender;
+    private Boolean isSuspended;
+
+    // name, email, nickname 통합 검색
+    private String keyword;
+
+    // 감사 필드 조건 (관리자용)
+    private LocalDateTime createdAtFrom;  // 가입일 시작
+    private LocalDateTime createdAtTo;    // 가입일 종료
+    private LocalDateTime updatedAtFrom;  // 수정일 시작
+    private LocalDateTime updatedAtTo;    // 수정일 종료
+    private UUID createdBy;               // 생성자 ID
+    private UUID updatedBy;               // 수정자 ID
+
+}

--- a/src/main/java/com/pagely/userservice/application/service/AuthApplicationService.java
+++ b/src/main/java/com/pagely/userservice/application/service/AuthApplicationService.java
@@ -1,7 +1,7 @@
 package com.pagely.userservice.application.service;
 
 import com.pagely.common.exception.BusinessException;
-import com.pagely.userservice.application.dto.LoginCommand;
+import com.pagely.userservice.application.dto.command.LoginCommand;
 import com.pagely.userservice.domain.exception.UserErrorCode;
 import com.pagely.userservice.domain.model.User;
 import com.pagely.userservice.domain.repository.UserRepository;

--- a/src/main/java/com/pagely/userservice/application/service/UserApplicationService.java
+++ b/src/main/java/com/pagely/userservice/application/service/UserApplicationService.java
@@ -1,7 +1,7 @@
 package com.pagely.userservice.application.service;
 
 import com.pagely.common.exception.BusinessException;
-import com.pagely.userservice.application.dto.SignupCommand;
+import com.pagely.userservice.application.dto.command.SignupCommand;
 import com.pagely.userservice.domain.exception.UserErrorCode;
 import com.pagely.userservice.domain.model.User;
 import com.pagely.userservice.domain.model.vo.Password;

--- a/src/main/java/com/pagely/userservice/application/service/UserQueryService.java
+++ b/src/main/java/com/pagely/userservice/application/service/UserQueryService.java
@@ -1,0 +1,50 @@
+package com.pagely.userservice.application.service;
+
+import com.pagely.common.exception.BusinessException;
+import com.pagely.userservice.application.dto.query.UserSearchCondition;
+import com.pagely.userservice.domain.exception.UserErrorCode;
+import com.pagely.userservice.domain.model.User;
+import com.pagely.userservice.domain.repository.UserQueryRepository;
+import com.pagely.userservice.presentation.dto.response.AdminUserInfoResponse;
+import com.pagely.userservice.presentation.dto.response.UserInfoResponse;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserQueryService {
+
+    private final UserQueryRepository userQueryRepository;
+
+    // 일반 단건 조회 - 기본 정보
+    public UserInfoResponse getUser(UUID id) {
+        User user = userQueryRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        return UserInfoResponse.from(user);
+    }
+
+    // 상세 단건 조회 - 감사(Audit) 정보 포함
+    public AdminUserInfoResponse getUserDetail(UUID id) {
+        User user = userQueryRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        return AdminUserInfoResponse.from(user);
+    }
+
+    // 내부 MSA 배치 조회
+    public List<UserInfoResponse> getUsersByIds(List<UUID> ids) {
+        return userQueryRepository.findAllByIds(ids).stream()
+                .map(UserInfoResponse::from)
+                .toList();
+    }
+
+    // 목록 조회 (동적 조건 + 페이징)
+    public Page<User> searchUsers(UserSearchCondition condition, Pageable pageable) {
+        return userQueryRepository.findAll(condition, pageable);
+    }
+}

--- a/src/main/java/com/pagely/userservice/domain/repository/UserQueryRepository.java
+++ b/src/main/java/com/pagely/userservice/domain/repository/UserQueryRepository.java
@@ -1,0 +1,19 @@
+package com.pagely.userservice.domain.repository;
+
+import com.pagely.userservice.application.dto.query.UserSearchCondition;
+import com.pagely.userservice.domain.model.User;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserQueryRepository {
+
+    Optional<User> findById(UUID id);
+
+    Page<User> findAll(UserSearchCondition condition, Pageable pageable);
+
+    // MSA 내부 서비스가 여러 사용자를 한 번에 조회할 때
+    List<User> findAllByIds(List<UUID> ids);
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/config/QueryDslConfig.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.pagely.userservice.infrastructure.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/persistence/querydsl/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/persistence/querydsl/UserQueryRepositoryImpl.java
@@ -63,10 +63,10 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
                         genderEq(cond.getGender()),
                         isSuspendedEq(cond.getIsSuspended()),
                         keywordSearch(cond.getKeyword()),
-                        createdAtBetween(cond.getCreatedAtFrom(), cond.getCreatedAtTo()),  // 추가
-                        updatedAtBetween(cond.getUpdatedAtFrom(), cond.getUpdatedAtTo()),  // 추가
-                        createdByEq(cond.getCreatedBy()),                                  // 추가
-                        updatedByEq(cond.getUpdatedBy()),                                  // 추가
+                        createdAtBetween(cond.getCreatedAtFrom(), cond.getCreatedAtTo()),
+                        updatedAtBetween(cond.getUpdatedAtFrom(), cond.getUpdatedAtTo()),
+                        createdByEq(cond.getCreatedBy()),
+                        updatedByEq(cond.getUpdatedBy()),
                         isNotDeleted()
                 )
                 .orderBy(user.createdAt.desc())
@@ -88,6 +88,10 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
                         genderEq(cond.getGender()),
                         isSuspendedEq(cond.getIsSuspended()),
                         keywordSearch(cond.getKeyword()),
+                        createdAtBetween(cond.getCreatedAtFrom(), cond.getCreatedAtTo()),
+                        updatedAtBetween(cond.getUpdatedAtFrom(), cond.getUpdatedAtTo()),
+                        createdByEq(cond.getCreatedBy()),
+                        updatedByEq(cond.getUpdatedBy()),
                         isNotDeleted()
                 )
                 .fetchOne();

--- a/src/main/java/com/pagely/userservice/infrastructure/persistence/querydsl/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/persistence/querydsl/UserQueryRepositoryImpl.java
@@ -1,0 +1,203 @@
+package com.pagely.userservice.infrastructure.persistence.querydsl;
+
+import com.pagely.common.auth.Role;
+import com.pagely.userservice.application.dto.query.UserSearchCondition;
+import com.pagely.userservice.domain.model.Gender;
+import com.pagely.userservice.domain.model.QUser;
+import com.pagely.userservice.domain.model.User;
+import com.pagely.userservice.domain.repository.UserQueryRepository;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQueryRepositoryImpl implements UserQueryRepository {
+
+    private final JPAQueryFactory queryFactory; // QueryDSL이 제공하는 쿼리 생성 빌더
+    private static final QUser user = QUser.user; // APT가 생성한 Q클래스
+
+    // ================================================================
+    // 단건 조회
+    // ================================================================
+
+    @Override
+    public Optional<User> findById(UUID id) {
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(user)
+                        .where(
+                                user.id.eq(id),
+                                isNotDeleted()
+                        )
+                        .fetchOne()
+        );
+    }
+
+    // ================================================================
+    // 다건 조회 (동적 조건 + 페이징)
+    // ================================================================
+
+    @Override
+    public Page<User> findAll(UserSearchCondition cond, Pageable pageable) {
+        // 1. 데이터 조회
+        List<User> content = queryFactory
+                .selectFrom(user)
+                .where(
+                        idsIn(cond.getIds()),
+                        loginIdEq(cond.getLoginId()),
+                        nameContains(cond.getName()),
+                        emailEq(cond.getEmail()),
+                        nicknameContains(cond.getNickname()),
+                        roleEq(cond.getRole()),
+                        genderEq(cond.getGender()),
+                        isSuspendedEq(cond.getIsSuspended()),
+                        keywordSearch(cond.getKeyword()),
+                        createdAtBetween(cond.getCreatedAtFrom(), cond.getCreatedAtTo()),  // 추가
+                        updatedAtBetween(cond.getUpdatedAtFrom(), cond.getUpdatedAtTo()),  // 추가
+                        createdByEq(cond.getCreatedBy()),                                  // 추가
+                        updatedByEq(cond.getUpdatedBy()),                                  // 추가
+                        isNotDeleted()
+                )
+                .orderBy(user.createdAt.desc())
+                .offset(pageable.getOffset())   // (page * size) 만큼 건너뜀
+                .limit(pageable.getPageSize())  // 최대 size개 가져옴
+                .fetch();
+
+        // 2. 카운트 쿼리 (페이지 총 개수 계산용, select/order 없이 조건만)
+        Long total = queryFactory
+                .select(user.count())
+                .from(user)
+                .where(
+                        idsIn(cond.getIds()),
+                        loginIdEq(cond.getLoginId()),
+                        nameContains(cond.getName()),
+                        emailEq(cond.getEmail()),
+                        nicknameContains(cond.getNickname()),
+                        roleEq(cond.getRole()),
+                        genderEq(cond.getGender()),
+                        isSuspendedEq(cond.getIsSuspended()),
+                        keywordSearch(cond.getKeyword()),
+                        isNotDeleted()
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total == null ? 0 : total);
+    }
+
+    // ================================================================
+    // 배치 조회 (MSA 내부 호출용)
+    // ================================================================
+
+    @Override
+    public List<User> findAllByIds(List<UUID> ids) {
+        if (CollectionUtils.isEmpty(ids)) {
+            return List.of();
+        }
+        return queryFactory
+                .selectFrom(user)
+                .where(
+                        user.id.in(ids),
+                        isNotDeleted()
+                )
+                .fetch();
+    }
+
+    // ================================================================
+    // 조건 메서드 - BooleanExpression
+    // null 반환 시 QueryDSL이 해당 where 조건을 자동으로 무시하게 된다.
+    // ================================================================
+
+    private BooleanExpression idsIn(List<UUID> ids) {
+        return CollectionUtils.isEmpty(ids) ? null : user.id.in(ids);
+    }
+
+    private BooleanExpression loginIdEq(String loginId) {
+        return StringUtils.hasText(loginId) ? user.loginId.eq(loginId) : null;
+    }
+
+    private BooleanExpression nameContains(String name) {
+        return StringUtils.hasText(name) ? user.name.contains(name) : null;
+    }
+
+    private BooleanExpression emailEq(String email) {
+        return StringUtils.hasText(email) ? user.email.eq(email) : null;
+    }
+
+    private BooleanExpression nicknameContains(String nickname) {
+        return StringUtils.hasText(nickname) ? user.nickname.contains(nickname) : null;
+    }
+
+    private BooleanExpression roleEq(Role role) {
+        return role != null ? user.role.eq(role) : null;
+    }
+
+    private BooleanExpression genderEq(Gender gender) {
+        return gender != null ? user.gender.eq(gender) : null;
+    }
+
+    private BooleanExpression isSuspendedEq(Boolean isSuspended) {
+        return isSuspended != null ? user.isSuspended.eq(isSuspended) : null;
+    }
+
+    // name OR email OR nickname 중 하나라도 포함되면 매칭
+    private BooleanExpression keywordSearch(String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            return null;
+        }
+        return user.name.containsIgnoreCase(keyword)
+                .or(user.email.containsIgnoreCase(keyword))
+                .or(user.nickname.containsIgnoreCase(keyword));
+    }
+
+    // 소프트 삭제 필터링 (공통모듈 BaseEntity.deletedAt 참고)
+    private BooleanExpression isNotDeleted() {
+        return user.deletedAt.isNull();
+    }
+
+    // ── 감사 필드 조건 ──────────────────────────────────────────────────────
+
+    private BooleanExpression createdAtBetween(LocalDateTime from, LocalDateTime to) {
+        if (from != null && to != null) {
+            return user.createdAt.between(from, to);
+        }
+        if (from != null) {
+            return user.createdAt.goe(from); // greater or equal
+        }
+        if (to != null) {
+            return user.createdAt.loe(to);   // less or equal
+        }
+        return null;
+    }
+
+    private BooleanExpression updatedAtBetween(LocalDateTime from, LocalDateTime to) {
+        if (from != null && to != null) {
+            return user.updatedAt.between(from, to);
+        }
+        if (from != null) {
+            return user.updatedAt.goe(from);
+        }
+        if (to != null) {
+            return user.updatedAt.loe(to);
+        }
+        return null;
+    }
+
+    private BooleanExpression createdByEq(UUID createdBy) {
+        return createdBy != null ? user.createdBy.eq(createdBy) : null;
+    }
+
+    private BooleanExpression updatedByEq(UUID updatedBy) {
+        return updatedBy != null ? user.updatedBy.eq(updatedBy) : null;
+    }
+}

--- a/src/main/java/com/pagely/userservice/presentation/controller/InternalUserController.java
+++ b/src/main/java/com/pagely/userservice/presentation/controller/InternalUserController.java
@@ -1,0 +1,80 @@
+package com.pagely.userservice.presentation.controller;
+
+import com.pagely.common.response.ApiResponse;
+import com.pagely.userservice.application.dto.query.UserSearchCondition;
+import com.pagely.userservice.application.service.UserQueryService;
+import com.pagely.userservice.presentation.dto.response.UserInfoResponse;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * MSA 내부 서비스 전용 컨트롤러. API Gateway에서 외부 접근 차단 (404)
+ * TODO: JavaDoc -> 문서화
+ */
+@RestController
+@RequestMapping("/internal/users")
+@RequiredArgsConstructor
+public class InternalUserController {
+
+    private final UserQueryService userQueryService;
+
+    /**
+     * <b>내부 서비스용 단건 조회</b>
+     * <ul>
+     * <li><b>용도:</b> 특정 유저의 기본 프로필 정보가 필요할 때 사용 (모임원 정보 등)</li>
+     * <li><b>호출 예시:</b> GET /internal/users/314fb54a-6bb3-46af-b7aa-799bd81bc047</li>
+     * <li><b>Feign:</b> UserInfoResponse getUser(@PathVariable("userId") UUID userId)</li>
+     * </ul>
+     */
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse> getUser(@PathVariable UUID userId) {
+        return ApiResponse.ok(userQueryService.getUser(userId));
+    }
+
+    /**
+     * <b>내부 서비스용 배치 조회</b>
+     * <ul>
+     * <li><b>용도:</b> 목록 페이지 등에서 여러 유저의 정보를 한꺼번에 조립할 때 사용</li>
+     * <li><b>호출 예시:</b> GET /internal/users/batch?ids=uuid1,uuid2,uuid3</li>
+     * <li><b>Feign:</b> List&lt;UserInfoResponse&gt; getUsersByIds(@RequestParam("ids") List&lt;UUID&gt; ids)</li>
+     * <li><b>주의:</b> 많은 양의 ID 조회 시 URL 길이 제한(414)에 주의</li>
+     * </ul>
+     */
+    @GetMapping("/batch")
+    public ResponseEntity<ApiResponse> getUsersByIds(@RequestParam List<UUID> ids) {
+        return ApiResponse.ok(userQueryService.getUsersByIds(ids));
+    }
+
+    /**
+     * <b>내부 서비스용 조건 검색</b>
+     * <ul>
+     * <li><b>용도:</b> 특정 조건에 맞는 유저 목록 추출</li>
+     * <li><b>Feign:</b> List&lt;UserInfoResponse&gt; searchUsers(@SpringQueryMap UserSearchCondition condition)</li>
+     * <li><b>보안 정책:</b>
+     * <ul>
+     * <li>성능 보호를 위해 1회 호출 시 <b>최대 1,000건</b>으로 제한됨</li>
+     * <li>전체 데이터가 필요할 경우 반복 호출(Paging) 필요</li>
+     * </ul>
+     * </li>
+     * </ul>
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse> searchUsers(
+            UserSearchCondition condition,
+            @PageableDefault(size = 1000) Pageable pageable
+    ) {
+        return ApiResponse.ok(
+                userQueryService.searchUsers(condition, pageable),
+                UserInfoResponse::from
+        );
+    }
+}

--- a/src/main/java/com/pagely/userservice/presentation/controller/InternalUserController.java
+++ b/src/main/java/com/pagely/userservice/presentation/controller/InternalUserController.java
@@ -63,6 +63,7 @@ public class InternalUserController {
      * <ul>
      * <li>성능 보호를 위해 1회 호출 시 <b>최대 1,000건</b>으로 제한됨</li>
      * <li>전체 데이터가 필요할 경우 반복 호출(Paging) 필요</li>
+     * <li>공통 모듈의 PageRequestArgumentResolver는 파라미터 타입이 PageRequest일 때만 동작 (v2.0.0 기준)</li>
      * </ul>
      * </li>
      * </ul>

--- a/src/main/java/com/pagely/userservice/presentation/controller/UserController.java
+++ b/src/main/java/com/pagely/userservice/presentation/controller/UserController.java
@@ -1,30 +1,72 @@
 package com.pagely.userservice.presentation.controller;
 
+import com.pagely.common.auth.Role;
+import com.pagely.common.auth.annotation.AuthRequired;
+import com.pagely.common.auth.annotation.CurrentUserId;
+import com.pagely.common.pagination.PageRequest;
 import com.pagely.common.response.ApiResponse;
+import com.pagely.userservice.application.dto.query.UserSearchCondition;
 import com.pagely.userservice.application.service.UserApplicationService;
+import com.pagely.userservice.application.service.UserQueryService;
 import com.pagely.userservice.presentation.dto.request.SignupRequest;
+import com.pagely.userservice.presentation.dto.response.AdminUserInfoResponse;
 import com.pagely.userservice.presentation.dto.response.SignupResponse;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * User REST 컨트롤러.
+ * User REST 컨트롤러. (외부 API)
  */
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserApplicationService userApplicationService;
+    private final UserQueryService userQueryService;
 
     @PostMapping
     public ResponseEntity<ApiResponse> signup(@Valid @RequestBody SignupRequest request) {
         SignupResponse response = userApplicationService.signup(request.toCommand());
         return ApiResponse.created(response);
+    }
+
+    // 사용자 단건 조회
+    @AuthRequired
+    @GetMapping
+    public ResponseEntity<ApiResponse> getUser(
+            @CurrentUserId UUID currentUserId) {
+        return ApiResponse.ok(userQueryService.getUser(currentUserId));
+    }
+
+    // 관리자용 단건 조회
+    @AuthRequired(role = Role.MASTER)
+    @GetMapping("/admin/{userId}")
+    public ResponseEntity<ApiResponse> getAdminUser(@PathVariable UUID userId
+    ) {
+        return ApiResponse.ok(userQueryService.getUserDetail(userId));
+    }
+
+    // 관리자용 목록 조회
+    @AuthRequired(role = Role.MASTER)
+    @GetMapping("/admin")
+    public ResponseEntity<ApiResponse> searchUsers(
+            UserSearchCondition condition,
+            PageRequest pageRequest
+    ) {
+        return ApiResponse.ok(
+                userQueryService.searchUsers(condition, pageRequest.toPageable()),
+                AdminUserInfoResponse::from
+        );
     }
 }

--- a/src/main/java/com/pagely/userservice/presentation/controller/UserController.java
+++ b/src/main/java/com/pagely/userservice/presentation/controller/UserController.java
@@ -1,19 +1,12 @@
 package com.pagely.userservice.presentation.controller;
 
-import com.pagely.common.auth.Role;
-import com.pagely.common.auth.annotation.AuthRequired;
-import com.pagely.common.auth.annotation.CurrentUserId;
-import com.pagely.common.auth.annotation.CurrentUserRole;
 import com.pagely.common.response.ApiResponse;
 import com.pagely.userservice.application.service.UserApplicationService;
 import com.pagely.userservice.presentation.dto.request.SignupRequest;
 import com.pagely.userservice.presentation.dto.response.SignupResponse;
 import jakarta.validation.Valid;
-import java.util.Map;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,18 +27,4 @@ public class UserController {
         SignupResponse response = userApplicationService.signup(request.toCommand());
         return ApiResponse.created(response);
     }
-
-    // TODO: 다음 PR에서 삭제 (정상 동작 확인 기록)
-    @GetMapping("/test")
-    @AuthRequired
-    public ResponseEntity<ApiResponse> debugMe(
-            @CurrentUserId UUID userId,
-            @CurrentUserRole Role role
-    ) {
-        return ApiResponse.ok(Map.of(
-                "userId", userId.toString(),
-                "role", role.name()
-        ));
-    }
-
 }

--- a/src/main/java/com/pagely/userservice/presentation/dto/request/LoginRequest.java
+++ b/src/main/java/com/pagely/userservice/presentation/dto/request/LoginRequest.java
@@ -1,6 +1,6 @@
 package com.pagely.userservice.presentation.dto.request;
 
-import com.pagely.userservice.application.dto.LoginCommand;
+import com.pagely.userservice.application.dto.command.LoginCommand;
 import jakarta.validation.constraints.NotBlank;
 
 /**

--- a/src/main/java/com/pagely/userservice/presentation/dto/request/SignupRequest.java
+++ b/src/main/java/com/pagely/userservice/presentation/dto/request/SignupRequest.java
@@ -1,6 +1,6 @@
 package com.pagely.userservice.presentation.dto.request;
 
-import com.pagely.userservice.application.dto.SignupCommand;
+import com.pagely.userservice.application.dto.command.SignupCommand;
 import com.pagely.userservice.domain.model.Gender;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/pagely/userservice/presentation/dto/response/AdminUserInfoResponse.java
+++ b/src/main/java/com/pagely/userservice/presentation/dto/response/AdminUserInfoResponse.java
@@ -1,0 +1,46 @@
+package com.pagely.userservice.presentation.dto.response;
+
+import com.pagely.common.auth.Role;
+import com.pagely.userservice.domain.model.Gender;
+import com.pagely.userservice.domain.model.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record AdminUserInfoResponse(
+        UUID id,
+        String loginId,
+        String name,
+        String nickname,
+        String email,
+        String phone,
+        Role role,
+        Gender gender,
+        LocalDate birthDate,
+        Integer rating,
+        Boolean isSuspended,
+        LocalDateTime createdAt,
+        UUID createdBy,
+        LocalDateTime updatedAt,
+        UUID updatedBy
+) {
+    public static AdminUserInfoResponse from(User user) {
+        return new AdminUserInfoResponse(
+                user.getId(),
+                user.getLoginId(),
+                user.getName(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getPhone(),
+                user.getRole(),
+                user.getGender(),
+                user.getBirthDate(),
+                user.getRating(),
+                user.getIsSuspended(),
+                user.getCreatedAt(),
+                user.getCreatedBy(),
+                user.getUpdatedAt(),
+                user.getUpdatedBy()
+        );
+    }
+}

--- a/src/main/java/com/pagely/userservice/presentation/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/pagely/userservice/presentation/dto/response/UserInfoResponse.java
@@ -1,0 +1,40 @@
+package com.pagely.userservice.presentation.dto.response;
+
+import com.pagely.common.auth.Role;
+import com.pagely.userservice.domain.model.Gender;
+import com.pagely.userservice.domain.model.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UserInfoResponse(
+        UUID id,
+        String loginId,
+        String name,
+        String nickname,
+        String email,
+        String phone,
+        Role role,
+        Gender gender,
+        LocalDate birthDate,
+        Integer rating,
+        Boolean isSuspended,
+        LocalDateTime createdAt
+) {
+    public static UserInfoResponse from(User user) {
+        return new UserInfoResponse(
+                user.getId(),
+                user.getLoginId(),
+                user.getName(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getPhone(),
+                user.getRole(),
+                user.getGender(),
+                user.getBirthDate(),
+                user.getRating(),
+                user.getIsSuspended(),
+                user.getCreatedAt()
+        );
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- User 정보 조회 API 구현

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #39   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #38 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="722" height="623" alt="image" src="https://github.com/user-attachments/assets/670bd068-09f6-49c7-becd-b30bfa45a6a9" />
<img width="721" height="598" alt="image" src="https://github.com/user-attachments/assets/a649579e-3e78-4918-a116-e415b64fc6d7" />
<img width="733" height="592" alt="image" src="https://github.com/user-attachments/assets/d3e51252-c2e1-4198-9cfd-f7588b87e7c0" />

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
- [ ] : API 문서 추가 작성 여부
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 조회 API 추가 (GET /api/v1/users) — 현재 사용자 정보 반환
  * 관리자 전용 사용자 상세 조회 (GET /api/v1/users/admin/{userId}) 및 검색 API (GET /api/v1/users/admin) — 필터/페이징 지원
  * 내부 서비스용 벌크 조회 엔드포인트 추가 (/internal/users)

* **New DTOs**
  * 상세/요약 사용자 응답 DTO 추가 (관리자용 및 일반용)

* **Refactor**
  * 사용자 검색 조건 및 QueryDSL 기반 조회 서비스/저장소 추가
  * 명령/요청 DTO 패키지 구조 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->