### PR TITLE
Feat/44 UserCreated 이벤트 발행 (Outbox 패턴 + Kafka)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ ext {
 }
 
 dependencies {
-    implementation "com.pagely:common:2.0.0"
+    implementation "com.pagely:common:2.0.1"
     // Kafka
     implementation 'org.springframework.kafka:spring-kafka'
     // QueryDSL (core는 common에서 전파, jpa+apt만 추가)

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ ext {
 
 dependencies {
     implementation "com.pagely:common:2.0.0"
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
     // QueryDSL (core는 common에서 전파, jpa+apt만 추가)
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
     annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'

--- a/src/main/java/com/pagely/userservice/UserServiceApplication.java
+++ b/src/main/java/com/pagely/userservice/UserServiceApplication.java
@@ -1,12 +1,13 @@
 package com.pagely.userservice;
 
+import com.pagely.userservice.infrastructure.config.AdminProperties;
 import com.pagely.userservice.infrastructure.security.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({JwtProperties.class, AdminProperties.class})
 public class UserServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/pagely/userservice/application/service/UserApplicationService.java
+++ b/src/main/java/com/pagely/userservice/application/service/UserApplicationService.java
@@ -34,10 +34,6 @@ public class UserApplicationService {
 
     @Transactional
     public SignupResponse signup(SignupCommand command) {
-        // 1. 중복 검사
-        validateDuplicate(command);
-
-        // 2. 도메인 객체 생성
         Password password = Password.of(command.password(), passwordEncoder);
         User user = User.create(
                 command.loginId(),
@@ -58,57 +54,14 @@ public class UserApplicationService {
                 NicknameChangeReason.CREATE
         );
 
-        // 3. 저장 (DB UNIQUE 제약 위반 시 race condition 방어)
         try {
-            User saved = userRepository.save(user);
+            User saved = userRepository.save(user); // save() 대신 saveAndFlush()를 사용하여 즉시 제약 조건을 검사함
             nicknameHistoryRepository.save(nicknameHistory);
             eventPublisher.publishEvent(UserCreatedEvent.from(saved));
             return SignupResponse.from(saved);
         } catch (DataIntegrityViolationException e) {
-            // 사전 검사 통과했으나 동시 가입 race condition 발생
-            log.warn("회원가입 동시성 충돌: loginId={}, email={}",
-                    command.loginId(), command.email(), e);
-            // @Transactional에 의해 User와 History 모두를 롤백
-            throw resolveDuplicateException(command, e);
+            throw resolveDuplicateException(e);
         }
-    }
-
-    /**
-     * 사전 중복 검사. existsBy* 메서드 활용.
-     */
-    private void validateDuplicate(SignupCommand command) {
-        if (userRepository.existsByLoginId(command.loginId())) {
-            throw new BusinessException(UserErrorCode.DUPLICATE_LOGIN_ID);
-        }
-        if (userRepository.existsByEmail(command.email())) {
-            throw new BusinessException(UserErrorCode.DUPLICATE_EMAIL);
-        }
-        if (userRepository.existsByNickname(command.nickname())) {
-            throw new BusinessException(UserErrorCode.DUPLICATE_NICKNAME);
-        }
-    }
-
-    /**
-     * DataIntegrityViolationException의 메시지에서 충돌 컬럼 식별.
-     */
-    private BusinessException resolveDuplicateException(
-            SignupCommand command,
-            DataIntegrityViolationException e
-    ) {
-        String message = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
-
-        if (message.contains("login_id")) {
-            return new BusinessException(UserErrorCode.DUPLICATE_LOGIN_ID, e);
-        }
-        if (message.contains("email")) {
-            return new BusinessException(UserErrorCode.DUPLICATE_EMAIL, e);
-        }
-        if (message.contains("nickname")) {
-            return new BusinessException(UserErrorCode.DUPLICATE_NICKNAME, e);
-        }
-
-        // 어느 컬럼인지 모르면 일반 충돌로 처리
-        return new BusinessException(UserErrorCode.DUPLICATE_LOGIN_ID, e);
     }
 
     /**
@@ -129,6 +82,7 @@ public class UserApplicationService {
                     .map(UserNicknameHistory::getChangedAt)
                     .orElse(null);
             validateNickname30Days(lastChangedAt);
+
             user.changeNickname(command.nickname());
 
             nicknameHistoryRepository.save(UserNicknameHistory.of(
@@ -144,6 +98,12 @@ public class UserApplicationService {
                 command.gender(),
                 command.birthDate()
         );
+        try {
+            userRepository.save(user);
+
+        } catch (DataIntegrityViolationException e) {
+            throw resolveDuplicateException(e);
+        }
     }
 
     /**
@@ -182,6 +142,11 @@ public class UserApplicationService {
                 command.rating(),
                 command.isSuspended()
         );
+        try {
+            userRepository.save(user);
+        } catch (DataIntegrityViolationException e) {
+            throw resolveDuplicateException(e);
+        }
     }
 
     /**
@@ -192,5 +157,28 @@ public class UserApplicationService {
         if (lastChangedAt != null && lastChangedAt.plusDays(30).isAfter(LocalDateTime.now())) {
             throw new BusinessException(UserErrorCode.NICKNAME_CHANGE_LIMIT);
         }
+    }
+
+    /**
+     * DataIntegrityViolationException의 메시지에서 충돌 컬럼 식별.
+     */
+    private BusinessException resolveDuplicateException(DataIntegrityViolationException e) {
+        String message = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
+
+        //log.error("=== DataIntegrityViolation message: {}", message); // 임시 로그 추가
+
+        // constraint [...] 부분만 추출해서 판단
+        if (message.contains("uk_p_users_login_id")) {
+            return new BusinessException(UserErrorCode.DUPLICATE_LOGIN_ID, e);
+        }
+        if (message.contains("uk_p_users_email")) {
+            return new BusinessException(UserErrorCode.DUPLICATE_EMAIL, e);
+        }
+        if (message.contains("uk_p_users_nickname")) {
+            return new BusinessException(UserErrorCode.DUPLICATE_NICKNAME, e);
+        }
+
+        // 어느 컬럼인지 모르면 일반 충돌로 처리
+        return new BusinessException(UserErrorCode.DUPLICATE, e);
     }
 }

--- a/src/main/java/com/pagely/userservice/application/service/UserApplicationService.java
+++ b/src/main/java/com/pagely/userservice/application/service/UserApplicationService.java
@@ -12,11 +12,13 @@ import com.pagely.userservice.domain.model.vo.Password;
 import com.pagely.userservice.domain.repository.UserNicknameHistoryRepository;
 import com.pagely.userservice.domain.repository.UserRepository;
 import com.pagely.userservice.domain.service.PasswordEncoder;
+import com.pagely.userservice.infrastructure.messaging.event.UserCreatedEvent;
 import com.pagely.userservice.presentation.dto.response.SignupResponse;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserApplicationService {
     private final UserNicknameHistoryRepository nicknameHistoryRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -59,6 +62,7 @@ public class UserApplicationService {
         try {
             User saved = userRepository.save(user);
             nicknameHistoryRepository.save(nicknameHistory);
+            eventPublisher.publishEvent(UserCreatedEvent.from(saved));
             return SignupResponse.from(saved);
         } catch (DataIntegrityViolationException e) {
             // 사전 검사 통과했으나 동시 가입 race condition 발생

--- a/src/main/java/com/pagely/userservice/application/service/UserApplicationService.java
+++ b/src/main/java/com/pagely/userservice/application/service/UserApplicationService.java
@@ -1,5 +1,7 @@
 package com.pagely.userservice.application.service;
 
+import com.pagely.common.auth.UserContext;
+import com.pagely.common.auth.UserContextHolder;
 import com.pagely.common.exception.BusinessException;
 import com.pagely.userservice.application.dto.command.SignupCommand;
 import com.pagely.userservice.application.dto.command.UpdateInfoCommand;
@@ -53,7 +55,8 @@ public class UserApplicationService {
                 user.getId(),
                 NicknameChangeReason.CREATE
         );
-
+        // AuditorAware가 신규 유저 본인 ID를 읽어갈 수 있도록 컨텍스트 주입
+        UserContextHolder.set(new UserContext(user.getId(), user.getRole()));
         try {
             User saved = userRepository.save(user); // save() 대신 saveAndFlush()를 사용하여 즉시 제약 조건을 검사함
             nicknameHistoryRepository.save(nicknameHistory);
@@ -61,6 +64,8 @@ public class UserApplicationService {
             return SignupResponse.from(saved);
         } catch (DataIntegrityViolationException e) {
             throw resolveDuplicateException(e);
+        } finally {
+            UserContextHolder.clear(); // ThreadLocal 정리
         }
     }
 

--- a/src/main/java/com/pagely/userservice/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/pagely/userservice/domain/exception/UserErrorCode.java
@@ -19,7 +19,8 @@ public enum UserErrorCode implements ErrorCode {
     PASSWORD_WHITESPACE_NOT_ALLOWED("비밀번호에 공백은 사용할 수 없습니다.", HttpStatus.BAD_REQUEST),
     NICKNAME_CHANGE_LIMIT("닉네임은 변경으로부터 30일 이내에 수정할 수 없습니다.", HttpStatus.BAD_REQUEST),
 
-    // 409 - 회원가입
+    // 409 - 중복 데이터
+    DUPLICATE("데이터 중복 오류 (이미 사용중인 이메일/닉네임 등)", HttpStatus.CONFLICT),
     DUPLICATE_LOGIN_ID("이미 사용 중인 로그인 아이디입니다.", HttpStatus.CONFLICT),
     DUPLICATE_EMAIL("이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),
     DUPLICATE_NICKNAME("이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
@@ -32,7 +33,8 @@ public enum UserErrorCode implements ErrorCode {
     NICKNAME_HISTORY_NOT_FOUND("닉네임 변경 이력을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // 401 - 인증
-    INVALID_CREDENTIALS("로그인 정보가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED);
+    INVALID_CREDENTIALS("로그인 정보가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+    ;
     private final String code;
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/pagely/userservice/domain/model/User.java
+++ b/src/main/java/com/pagely/userservice/domain/model/User.java
@@ -97,9 +97,7 @@ public class User extends BaseEntity implements Persistable<UUID> {
         user.birthDate = birthDate;
         user.rating = 1000;
         user.isSuspended = false;
-
-        user.createdBy = user.id;
-        user.updatedBy = user.id;
+        
         return user;
     }
 

--- a/src/main/java/com/pagely/userservice/domain/repository/UserNicknameHistoryRepository.java
+++ b/src/main/java/com/pagely/userservice/domain/repository/UserNicknameHistoryRepository.java
@@ -10,6 +10,7 @@ public interface UserNicknameHistoryRepository {
 
     /**
      * 특정 유저의 가장 최근 닉네임 변경 이력을 조회. 서비스 레이어에서 30일 제한(validateNickname30Days)을 체크할 때 사용합니다.
+     * <p>단, 'CREATE', 'USER_CHANGE'와 같이 사용자에 의한 변경 사유만 포함합니다.
      */
     Optional<UserNicknameHistory> findFirstByUserIdOrderByChangedAtDesc(UUID userId);
 }

--- a/src/main/java/com/pagely/userservice/infrastructure/config/AdminProperties.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/config/AdminProperties.java
@@ -1,0 +1,13 @@
+package com.pagely.userservice.infrastructure.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 서버 최초 실행시 만들어지는 Master계정 관련 설정
+ */
+@ConfigurationProperties(prefix = "init.admin")
+public record AdminProperties(
+        String id,
+        String password
+) {
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/config/FlywayConfig.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/config/FlywayConfig.java
@@ -1,0 +1,23 @@
+package com.pagely.userservice.infrastructure.config;
+
+import com.pagely.userservice.infrastructure.security.BCryptPasswordEncoder;
+import java.util.Map;
+import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FlywayConfig {
+    @Bean
+    public FlywayConfigurationCustomizer flywayCustomizer(
+            AdminProperties adminProps) {
+        return configuration -> {
+            // 사양에 따라 알고리즘 선택 가능 (BCrypt, Argon2 등)
+            String hashed = new BCryptPasswordEncoder().encode(adminProps.password());
+            configuration.placeholders(Map.of(
+                    "adminId", adminProps.id(),
+                    "encodedPassword", hashed));
+        };
+
+    }
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/config/SchedulerConfig.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.pagely.userservice.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/messaging/event/BaseEvent.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/messaging/event/BaseEvent.java
@@ -1,0 +1,59 @@
+package com.pagely.userservice.infrastructure.messaging.event;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+
+/**
+ * 도메인 이벤트의 공통 메타 정보.
+ * <p>
+ * 향후 pagely-common 으로 이관 (예정)</p>
+ *
+ * <p><b>설계 의도</b></p>
+ * <ul>
+ *   <li>{@code eventId}: 이벤트 고유 식별자 (Consumer idempotency 용). UUID.toString().</li>
+ *   <li>{@code eventType}: 서브클래스명 자동 (예: "UserCreatedEvent").</li>
+ *   <li>{@code domainType}: 도메인 명명 (예: "USER"). aggregate type.</li>
+ *   <li>{@code domainId}: 도메인 엔티티 ID (예: userId). Kafka 메시지 키로 활용.</li>
+ *   <li>{@code occurredAt}: Instant (UTC 기준) — 타임존 모호성 제거.</li>
+ *   <li>{@code payload}: 이벤트 본문 (도메인 데이터).</li>
+ * </ul>
+ *
+ * <p>String / Instant 사용 — 다른 언어 Consumer 호환.</p>
+ */
+@Getter
+public abstract class BaseEvent {
+
+    private final String eventId;
+    private final String eventType;
+    private final String domainType;
+    private final String domainId;
+    private final Instant occurredAt;
+    private final Object payload;
+
+    /**
+     * UUID 도메인 ID (대부분의 도메인 케이스).
+     */
+    protected BaseEvent(String domainType, UUID domainId, Object payload) {
+        this(domainType, domainId == null ? null : domainId.toString(), payload);
+    }
+
+    /**
+     * domainId 가 없는 케이스 (예: 시스템 이벤트).
+     */
+    protected BaseEvent(String domainType, Object payload) {
+        this(domainType, (String) null, payload);
+    }
+
+    /**
+     * 모든 생성자가 위임하는 메인 생성자.
+     */
+    protected BaseEvent(String domainType, String domainId, Object payload) {
+        this.eventId = UUID.randomUUID().toString();
+        this.eventType = this.getClass().getSimpleName();
+        this.domainType = domainType;
+        this.domainId = domainId;
+        this.occurredAt = Instant.now();
+        this.payload = payload;
+    }
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/messaging/event/UserCreatedEvent.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/messaging/event/UserCreatedEvent.java
@@ -1,0 +1,52 @@
+package com.pagely.userservice.infrastructure.messaging.event;
+
+import com.pagely.common.auth.Role;
+import com.pagely.userservice.domain.model.User;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 회원가입 완료 이벤트.
+ *
+ * <p>발행 위치: {@link com.pagely.userservice.application.service.UserApplicationService#signup}</p>
+ * <p>토픽: {@code user.created}</p>
+ *
+ * <p>다른 서비스의 Consumer 가 이 페이로드 스키마에 맞춰 ObjectMapper 매핑.</p>
+ */
+public class UserCreatedEvent extends BaseEvent {
+
+    public static final String DOMAIN_TYPE = "USER";
+    public static final String TOPIC = "user.created";
+
+    private UserCreatedEvent(UUID userId, Payload payload) {
+        super(DOMAIN_TYPE, userId, payload);
+    }
+
+    /**
+     * User 엔티티에서 이벤트 생성. 전화번호, 생일, 성별, 평점 등 민감 정보 제외 후 페이로드 구성.
+     */
+    public static UserCreatedEvent from(User user) {
+        Payload payload = new Payload(
+                user.getId(),
+                user.getLoginId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getRole(),
+                user.getCreatedAt()
+        );
+        return new UserCreatedEvent(user.getId(), payload);
+    }
+
+    /**
+     * 이벤트 페이로드 — 다른 서비스 Consumer 가 매핑
+     */
+    public record Payload(
+            UUID userId,
+            String loginId,
+            String email,
+            String nickname,
+            Role role,
+            LocalDateTime createdAt
+    ) {
+    }
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxEvent.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxEvent.java
@@ -1,0 +1,157 @@
+package com.pagely.userservice.infrastructure.messaging.outbox;
+
+import com.pagely.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.domain.Persistable;
+
+/**
+ * Outbox 패턴의 이벤트 저장 엔티티.
+ *
+ * <p><b>생명주기</b></p>
+ * <ol>
+ *   <li>도메인 트랜잭션 안에서 {@link #of} 로 생성 + 저장 (published=false)</li>
+ *   <li>OutboxPoller 가 미발행 이벤트 조회</li>
+ *   <li>Kafka 발행 성공 시 {@link #markPublished} 호출 → published=true</li>
+ *   <li>발행 실패 시 {@link #recordFailure} 호출 → failure_count++</li>
+ * </ol>
+ *
+ * <p><b>id 와 aggregate_id 차이</b></p>
+ * <ul>
+ *   <li>id: Outbox 엔티티 자체의 PK (UUID 자동 생성)</li>
+ *   <li>aggregate_id: 이벤트가 가리키는 도메인의 엔티티의 ID (예: User.id)</li>
+ * </ul>
+ */
+@Entity
+@Getter
+@Table(name = "p_outbox")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OutboxEvent extends BaseEntity implements Persistable<UUID> {
+
+    @Id
+    @Column(columnDefinition = "UUID")
+    private UUID id;
+
+    @Column(name = "aggregate_type", nullable = false, length = 50)
+    private String aggregateType;
+
+    @Column(name = "aggregate_id", nullable = false, columnDefinition = "UUID")
+    private UUID aggregateId;
+
+    @Column(name = "event_type", nullable = false, length = 100)
+    private String eventType;
+
+    @Column(name = "topic", nullable = false, length = 100)
+    private String topic;
+
+    /**
+     * JSON 직렬화된 이벤트 페이로드. Hibernate 6+ 가 String → JSONB 자동 매핑.
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "payload", nullable = false, columnDefinition = "JSONB")
+    private String payload;
+
+    @Column(name = "published", nullable = false)
+    private boolean published;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    @Column(name = "failure_count", nullable = false)
+    private int failureCount;
+
+    @Column(name = "last_failure_at")
+    private LocalDateTime lastFailureAt;
+
+    @Column(name = "last_failure_message", columnDefinition = "TEXT")
+    private String lastFailureMessage;
+
+    // ====================================================================
+    // 팩토리 메서드
+    // ====================================================================
+
+    /**
+     * 새 Outbox 이벤트 생성.
+     */
+    public static OutboxEvent of(
+            String aggregateType,
+            UUID aggregateId,
+            String eventType,
+            String topic,
+            String payload
+    ) {
+        if (aggregateType == null || aggregateType.isBlank()) {
+            throw new IllegalArgumentException("aggregateType 은 필수입니다.");
+        }
+        if (aggregateId == null) {
+            throw new IllegalArgumentException("aggregateId 는 필수입니다.");
+        }
+        if (eventType == null || eventType.isBlank()) {
+            throw new IllegalArgumentException("eventType 은 필수입니다.");
+        }
+        if (topic == null || topic.isBlank()) {
+            throw new IllegalArgumentException("topic 은 필수입니다.");
+        }
+        if (payload == null || payload.isBlank()) {
+            throw new IllegalArgumentException("payload 는 필수입니다.");
+        }
+
+        OutboxEvent event = new OutboxEvent();
+        event.id = UUID.randomUUID();
+        event.aggregateType = aggregateType;
+        event.aggregateId = aggregateId;
+        event.eventType = eventType;
+        event.topic = topic;
+        event.payload = payload;
+        event.published = false;
+        event.failureCount = 0;
+        return event;
+    }
+
+    // ====================================================================
+    // 상태 변경
+    // ====================================================================
+
+    /**
+     * 발행 성공 마킹.
+     */
+    public void markPublished() {
+        this.published = true;
+        this.publishedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 발행 실패 기록.
+     */
+    public void recordFailure(String message) {
+        this.failureCount++;
+        this.lastFailureAt = LocalDateTime.now();
+        this.lastFailureMessage = truncateMessage(message);
+    }
+
+    private String truncateMessage(String message) {
+        if (message == null) {
+            return null;
+        }
+        // 저장할 때 DB 부하 방지, 읽어올 때 메모리 절약, DB허용 길이 초과시 데이터 저장 자체 실패를 미리 방지
+        return message.length() > 2000 ? message.substring(0, 2000) : message;
+    }
+
+    // ====================================================================
+    // Persistable 구현
+    // ====================================================================
+
+    @Override
+    public boolean isNew() {
+        return getCreatedAt() == null;
+    }
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxEventHandler.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxEventHandler.java
@@ -1,0 +1,70 @@
+package com.pagely.userservice.infrastructure.messaging.outbox;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pagely.userservice.infrastructure.messaging.event.BaseEvent;
+import com.pagely.userservice.infrastructure.messaging.event.UserCreatedEvent;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 도메인 이벤트를 Outbox 테이블에 저장하는 핸들러.
+ *
+ * <p><b>동작 흐름</b></p>
+ * <ol>
+ *   <li>도메인 서비스가 ApplicationEventPublisher 로 이벤트 발행</li>
+ *   <li>이 핸들러가 BEFORE_COMMIT 시점에 호출됨 → 같은 트랜잭션 안에서 처리</li>
+ *   <li>JSON 직렬화 → 토픽 결정 → Outbox 저장</li>
+ *   <li>도메인 트랜잭션 커밋 시 User + Outbox 함께 커밋 (원자성)</li>
+ * </ol>
+ *
+ * <p>실제 Kafka 발행은 별도 OutboxPoller 가 담당 (Outbox 패턴).</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxEventHandler {
+
+    private final OutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void onDomainEvent(BaseEvent event) {
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            String topic = resolveTopic(event);
+            UUID aggregateId = UUID.fromString(event.getDomainId());
+
+            OutboxEvent outbox = OutboxEvent.of(
+                    event.getDomainType(),
+                    aggregateId,
+                    event.getEventType(),
+                    topic,
+                    payload
+            );
+            outboxRepository.save(outbox);
+
+            log.debug("Outbox 저장 완료: eventType={}, domainId={}, outboxId={}",
+                    event.getEventType(), event.getDomainId(), outbox.getId());
+        } catch (JsonProcessingException e) {
+            log.error("이벤트 직렬화 실패: eventType={}", event.getEventType(), e);
+            throw new IllegalStateException("이벤트 직렬화 실패: " + event.getEventType(), e);
+        }
+    }
+
+    /**
+     * 이벤트 타입에 따른 Kafka 토픽 결정.
+     */
+    private String resolveTopic(BaseEvent event) {
+        return switch (event.getEventType()) {
+            case "UserCreatedEvent" -> UserCreatedEvent.TOPIC;
+            // TODO: case "UserProfileUpdatedEvent" -> UserProfileUpdatedEvent.TOPIC;
+            default -> throw new IllegalArgumentException(
+                    "Unsupported event type: " + event.getEventType());
+        };
+    }
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxPoller.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxPoller.java
@@ -1,0 +1,75 @@
+package com.pagely.userservice.infrastructure.messaging.outbox;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Outbox 미발행 이벤트를 Kafka 로 발행하는 스케줄러.
+ *
+ * <p><b>동작</b></p>
+ * <ol>
+ *   <li>5초마다 미발행 이벤트 BATCH_SIZE 개 조회</li>
+ *   <li>Kafka 로 발행</li>
+ *   <li>성공 → published=true 마킹</li>
+ *   <li>실패 → failure_count++, 다음 사이클에서 재시도</li>
+ * </ol>
+ *
+ * <p><b>메시지 키 = aggregate_id (UUID 문자열)</b></p>
+ * 같은 entity 의 이벤트는 같은 파티션 → 순서 보장.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxPoller {
+
+    private static final int BATCH_SIZE = 100;
+
+    private final OutboxRepository outboxRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    @Scheduled(fixedDelayString = "${outbox.poll-interval-ms:5000}")
+    @Transactional
+    public void publishPendingEvents() {
+        List<OutboxEvent> events = outboxRepository.findUnpublished(
+                PageRequest.of(0, BATCH_SIZE)
+        );
+
+        if (events.isEmpty()) {
+            return;
+        }
+
+        log.debug("Outbox 발행 시작: count={}", events.size());
+
+        for (OutboxEvent event : events) {
+            try {
+                publishToKafka(event);
+                event.markPublished();
+            } catch (Exception e) {
+                event.recordFailure(e.getMessage());
+                log.error("Outbox 발행 실패: outboxId={}, eventType={}, failureCount={}",
+                        event.getId(), event.getEventType(), event.getFailureCount(), e);
+            }
+        }
+
+        log.debug("Outbox 발행 완료: count={}", events.size());
+    }
+
+    private void publishToKafka(OutboxEvent event) throws ExecutionException, InterruptedException {
+        String topic = event.getTopic();
+        String messageKey = event.getAggregateId().toString();
+        String payload = event.getPayload();
+
+        // 동기 발행 — 실패 시 즉시 catch 가능 (성능보다 신뢰성 우선)
+        kafkaTemplate.send(topic, messageKey, payload).get();
+
+        log.debug("Kafka 발행 성공: topic={}, key={}, eventType={}",
+                topic, messageKey, event.getEventType());
+    }
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxRepository.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxRepository.java
@@ -1,0 +1,29 @@
+package com.pagely.userservice.infrastructure.messaging.outbox;
+
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Outbox 이벤트 영속성 인터페이스 (Port).
+ *
+ * <p>OutboxEventHandler 와 OutboxPoller 가 사용.</p>
+ */
+public interface OutboxRepository {
+
+    /**
+     * Outbox 이벤트 저장.
+     */
+    OutboxEvent save(OutboxEvent event);
+
+    /**
+     * 미발행 이벤트 조회 (created_at 오름차순).
+     *
+     * <p>Poller 가 batch 단위로 가져오기 위해 Pageable 사용.</p>
+     */
+    List<OutboxEvent> findUnpublished(Pageable pageable);
+
+    /**
+     * 발행 시도 횟수가 일정 임계 이상인 이벤트 (모니터링)
+     */
+    List<OutboxEvent> findFailedExceedingThreshold(int threshold, Pageable pageable);
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxRepositoryAdapter.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxRepositoryAdapter.java
@@ -1,0 +1,29 @@
+package com.pagely.userservice.infrastructure.messaging.outbox;
+
+import com.pagely.userservice.infrastructure.persistence.jpa.JpaOutboxRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryAdapter implements OutboxRepository {
+
+    private final JpaOutboxRepository jpaRepository;
+
+    @Override
+    public OutboxEvent save(OutboxEvent event) {
+        return jpaRepository.save(event);
+    }
+
+    @Override
+    public List<OutboxEvent> findUnpublished(Pageable pageable) {
+        return jpaRepository.findUnpublished(pageable);
+    }
+
+    @Override
+    public List<OutboxEvent> findFailedExceedingThreshold(int threshold, Pageable pageable) {
+        return jpaRepository.findFailedExceedingThreshold(threshold, pageable);
+    }
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/persistence/UserNicknameHistoryRepositoryAdapter.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/persistence/UserNicknameHistoryRepositoryAdapter.java
@@ -1,8 +1,10 @@
 package com.pagely.userservice.infrastructure.persistence;
 
+import com.pagely.userservice.domain.model.NicknameChangeReason;
 import com.pagely.userservice.domain.model.UserNicknameHistory;
 import com.pagely.userservice.domain.repository.UserNicknameHistoryRepository;
 import com.pagely.userservice.infrastructure.persistence.jpa.JpaUserNicknameHistoryRepository;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,9 @@ public class UserNicknameHistoryRepositoryAdapter implements UserNicknameHistory
 
     private final JpaUserNicknameHistoryRepository jpaRepository;
 
+    private static final List<NicknameChangeReason> SELF_CHANGE_REASONS =
+            List.of(NicknameChangeReason.CREATE, NicknameChangeReason.USER_CHANGE);
+
     @Override
     public UserNicknameHistory save(UserNicknameHistory history) {
         return jpaRepository.save(history);
@@ -21,6 +26,6 @@ public class UserNicknameHistoryRepositoryAdapter implements UserNicknameHistory
 
     @Override
     public Optional<UserNicknameHistory> findFirstByUserIdOrderByChangedAtDesc(UUID userId) {
-        return jpaRepository.findFirstByUserIdOrderByChangedAtDesc(userId);
+        return jpaRepository.findFirstByUserIdAndReasonInOrderByChangedAtDesc(userId, SELF_CHANGE_REASONS);
     }
 }

--- a/src/main/java/com/pagely/userservice/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/persistence/UserRepositoryAdapter.java
@@ -16,7 +16,7 @@ public class UserRepositoryAdapter implements UserRepository {
 
     @Override
     public User save(User user) {
-        return jpaUserRepository.save(user);
+        return jpaUserRepository.saveAndFlush(user); // DataIntegrityViolationException catch
     }
 
     @Override

--- a/src/main/java/com/pagely/userservice/infrastructure/persistence/jpa/JpaOutboxRepository.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/persistence/jpa/JpaOutboxRepository.java
@@ -1,0 +1,42 @@
+package com.pagely.userservice.infrastructure.persistence.jpa;
+
+import com.pagely.userservice.infrastructure.messaging.outbox.OutboxEvent;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+/**
+ * Spring Data JPA OutboxEvent Repository.
+ *
+ * <p>{@link com.pagely.userservice.infrastructure.messaging.outbox.OutboxRepositoryAdapter}
+ * 가 이걸 위임 호출.</p>
+ */
+public interface JpaOutboxRepository extends JpaRepository<OutboxEvent, UUID> {
+
+    /**
+     * 미발행 이벤트 조회.
+     *
+     * <p>인덱스 idx_outbox_unpublished 적중을 위해 published=false + deleted_at IS NULL 조건.</p>
+     */
+    @Query("""
+            SELECT e FROM OutboxEvent e
+            WHERE e.published = false
+              AND e.deletedAt IS NULL
+            ORDER BY e.createdAt ASC
+            """)
+    List<OutboxEvent> findUnpublished(Pageable pageable);
+
+    /**
+     * 발행 실패 횟수가 임계값 이상인 이벤트 조회 (운영 모니터링).
+     */
+    @Query("""
+            SELECT e FROM OutboxEvent e
+            WHERE e.published = false
+              AND e.failureCount >= :threshold
+              AND e.deletedAt IS NULL
+            ORDER BY e.lastFailureAt DESC
+            """)
+    List<OutboxEvent> findFailedExceedingThreshold(int threshold, Pageable pageable);
+}

--- a/src/main/java/com/pagely/userservice/infrastructure/persistence/jpa/JpaUserNicknameHistoryRepository.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/persistence/jpa/JpaUserNicknameHistoryRepository.java
@@ -1,6 +1,8 @@
 package com.pagely.userservice.infrastructure.persistence.jpa;
 
+import com.pagely.userservice.domain.model.NicknameChangeReason;
 import com.pagely.userservice.domain.model.UserNicknameHistory;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +11,7 @@ public interface JpaUserNicknameHistoryRepository extends JpaRepository<UserNick
     /**
      * 특정 유저의 이력 중 가장 최근(Desc) 1건(First)만 조회
      */
-    Optional<UserNicknameHistory> findFirstByUserIdOrderByChangedAtDesc(UUID userId);
+    Optional<UserNicknameHistory> findFirstByUserIdAndReasonInOrderByChangedAtDesc(UUID userId,
+                                                                                   List<NicknameChangeReason> selfChangeReasons);
 
 }

--- a/src/main/java/com/pagely/userservice/presentation/controller/UserController.java
+++ b/src/main/java/com/pagely/userservice/presentation/controller/UserController.java
@@ -38,31 +38,16 @@ public class UserController {
     private final UserApplicationService userApplicationService;
     private final UserQueryService userQueryService;
 
+    // [생성] 회원가입
     @PostMapping
     public ResponseEntity<ApiResponse> signup(@Valid @RequestBody SignupRequest request) {
         SignupResponse response = userApplicationService.signup(request.toCommand());
         return ApiResponse.created(response);
     }
 
-    // 사용자 단건 조회
-    @AuthRequired
+    // [목록 조회] 전체 사용자 목록 (관리자용)
     @GetMapping
-    public ResponseEntity<ApiResponse> getUser(
-            @CurrentUserId UUID currentUserId) {
-        return ApiResponse.ok(userQueryService.getUser(currentUserId));
-    }
-
-    // 관리자용 단건 조회
     @AuthRequired(role = Role.MASTER)
-    @GetMapping("/admin/{userId}")
-    public ResponseEntity<ApiResponse> getAdminUser(@PathVariable UUID userId
-    ) {
-        return ApiResponse.ok(userQueryService.getUserDetail(userId));
-    }
-
-    // 관리자용 목록 조회
-    @AuthRequired(role = Role.MASTER)
-    @GetMapping("/admin")
     public ResponseEntity<ApiResponse> searchUsers(
             UserSearchCondition condition,
             PageRequest pageRequest
@@ -73,17 +58,14 @@ public class UserController {
         );
     }
 
-    // 사용자 본인 정보 수정
-    @AuthRequired
-    @PatchMapping("/me")
-    public ResponseEntity<Void> updateMyProfile(
-            @CurrentUserId UUID currentUserId,
-            @Valid @RequestBody UpdateProfileRequest request) {
-        userApplicationService.updateMyProfile(
-                currentUserId, request.toCommand());
-        return ResponseEntity.ok().build();
+    // [단건 조회] 특정 사용자 조회 (관리자용)
+    @GetMapping("/{userId}")
+    @AuthRequired(role = Role.MASTER)
+    public ResponseEntity<ApiResponse> getAdminUser(@PathVariable UUID userId) {
+        return ApiResponse.ok(userQueryService.getUserDetail(userId));
     }
 
+    // [단건 수정] 특정 사용자 정보 수정 (관리자용)
     @PatchMapping("/{userId}")
     @AuthRequired(role = Role.MASTER)
     public ResponseEntity<Void> adminUpdateInfo(
@@ -91,6 +73,25 @@ public class UserController {
             @PathVariable UUID userId,
             @Valid @RequestBody UpdateInfoRequest request) {
         userApplicationService.adminUpdateInfo(currentUserId, userId, request.toCommand());
+        return ResponseEntity.ok().build();
+    }
+
+    // [단건 조회] 내 정보 조회
+    @GetMapping("/me")
+    @AuthRequired
+    public ResponseEntity<ApiResponse> getUser(
+            @CurrentUserId UUID currentUserId) {
+        return ApiResponse.ok(userQueryService.getUser(currentUserId));
+    }
+
+    // [단건 수정] 내 정보 수정
+    @PatchMapping("/me")
+    @AuthRequired
+    public ResponseEntity<Void> updateMyProfile(
+            @CurrentUserId UUID currentUserId,
+            @Valid @RequestBody UpdateProfileRequest request) {
+        userApplicationService.updateMyProfile(
+                currentUserId, request.toCommand());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,19 @@ spring:
     locations: classpath:db/migration
     baseline-on-migrate: true
 
+
+  kafka: # 이벤트 발행 시 kafka message header에 __TypeId__ 발행을 하지 않고, Json String으로 발행
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer #수신 서버에서 ObjectMapper 를 활용하여 수신 서버의 적절한 클래스로 직접 매핑
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false   # TypeId 헤더 비활성화
+        # 신뢰성 보강
+        acks: all                              # 모든 ISR 에 복제 확인 후 ACK
+        retries: 3                             # 발행 실패 시 재시도 횟수
+        enable.idempotence: true               # 중복 발행 방지 (Producer 측)
+
 logging:
   level:
     org.flywaydb: info

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,13 +29,17 @@ spring:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer #수신 서버에서 ObjectMapper 를 활용하여 수신 서버의 적절한 클래스로 직접 매핑
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      #  value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer # User 서비스에서는 직렬화된 상태로 발행
       properties:
         spring.json.add.type.headers: false   # TypeId 헤더 비활성화
         # 신뢰성 보강
         acks: all                              # 모든 ISR 에 복제 확인 후 ACK
         retries: 3                             # 발행 실패 시 재시도 횟수
         enable.idempotence: true               # 중복 발행 방지 (Producer 측)
+outbox:
+  poll-interval-ms: 5000  # 5초
+
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,3 +58,7 @@ eureka:
     fetch-registry: true
     serviceUrl:
       defaultZone: ${EUREKA_SERVER_URL:http://localhost:8000/eureka/}
+init:
+  admin:
+    id: ${ADMIN_ID}
+    password: ${ADMIN_PASSWORD}

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -44,3 +44,40 @@ CREATE UNIQUE INDEX uk_p_users_email
 
 CREATE UNIQUE INDEX uk_p_users_nickname
     ON p_users (nickname) WHERE deleted_at IS NULL;
+
+-- ============================================================
+-- MASTER 계정 초기화
+-- Flyway Placeholder 기능으로 환경변수 주입
+-- ============================================================
+
+INSERT INTO p_users (
+    id,
+    login_id,
+    password,
+    name,
+    role,
+    nickname,
+    email,
+    phone,
+    gender,
+    birth_date,
+    rating,
+    is_suspended,
+    created_at,
+    created_by
+) VALUES (
+             '11111111-1111-1111-1111-111111111111',
+             '${adminId}',
+             '${encodedPassword}',  -- Spring 에서 암호화한 뒤 변수로 넘겨줌
+             '관라자',
+             'MASTER',
+             'Admin',
+             'admin@pagely.com',
+             '010-0000-0000',
+             'MALE',
+             '1990-01-01',
+             9999,
+             false,
+             NOW(),
+             '00000000-0000-0000-0000-000000000000'
+         );

--- a/src/main/resources/db/migration/V3__create_outbox_table.sql
+++ b/src/main/resources/db/migration/V3__create_outbox_table.sql
@@ -1,0 +1,53 @@
+-- Outbox 테이블
+-- DB 트랜잭션 안에서 이벤트 기록 → 별도 Poller 가 Kafka 로 발행
+
+CREATE TABLE p_outbox
+(
+    -- 기본 식별자
+    id              UUID PRIMARY KEY,
+
+    -- 이벤트 메타
+    aggregate_type  VARCHAR(50)  NOT NULL,                 -- USER, MEETING 등
+    aggregate_id    UUID         NOT NULL,                 -- 엔티티 ID (메시지 키로 활용)
+    event_type      VARCHAR(100) NOT NULL,                 -- USER_CREATED, USER_UPDATED 등
+    topic           VARCHAR(100) NOT NULL,                 -- user.created, user.updated 등
+
+    -- 페이로드
+    payload         JSONB        NOT NULL,                 -- 이벤트 본문 (JSON)
+
+    -- 발행 추적
+    published       BOOLEAN      NOT NULL DEFAULT FALSE,
+    published_at    TIMESTAMP,
+    failure_count   INT          NOT NULL DEFAULT 0,
+    last_failure_at TIMESTAMP,
+    last_failure_message TEXT,
+
+    -- 감사 필드 (BaseEntity 와 동일)
+    created_at      TIMESTAMP    NOT NULL,
+    created_by      UUID         NOT NULL,
+    updated_at      TIMESTAMP,
+    updated_by      UUID,
+    deleted_at      TIMESTAMP,
+    deleted_by      UUID
+);
+
+-- Poller 가 가장 자주 사용할 인덱스
+-- "미발행 이벤트를 created_at 순으로 조회"
+CREATE INDEX idx_outbox_unpublished
+    ON p_outbox (created_at)
+    WHERE published = FALSE AND deleted_at IS NULL;
+
+-- 디버깅 / 운영용 — 특정 aggregate 의 이벤트 조회
+CREATE INDEX idx_outbox_aggregate
+    ON p_outbox (aggregate_type, aggregate_id)
+    WHERE deleted_at IS NULL;
+
+-- 코멘트 (PostgreSQL)
+COMMENT ON TABLE p_outbox IS 'Outbox 패턴 이벤트 저장소. Poller 가 published=false 인 이벤트를 Kafka 로 발행';
+COMMENT ON COLUMN p_outbox.aggregate_type IS '이벤트가 속한 도메인 타입 (USER, MEETING 등)';
+COMMENT ON COLUMN p_outbox.aggregate_id IS '이벤트의 entity ID. Kafka 메시지 키로 사용 (순서 보장)';
+COMMENT ON COLUMN p_outbox.event_type IS '구체적 이벤트 타입 (USER_CREATED 등)';
+COMMENT ON COLUMN p_outbox.topic IS '발행 대상 Kafka 토픽 (user.created 등)';
+COMMENT ON COLUMN p_outbox.payload IS '이벤트 본문 JSON';
+COMMENT ON COLUMN p_outbox.published IS '발행 완료 여부';
+COMMENT ON COLUMN p_outbox.failure_count IS '발행 실패 횟수 (재시도 추적)';

--- a/src/test/java/com/pagely/userservice/UserCreatedEventTest.java
+++ b/src/test/java/com/pagely/userservice/UserCreatedEventTest.java
@@ -1,0 +1,42 @@
+package com.pagely.userservice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.pagely.userservice.domain.model.Gender;
+import com.pagely.userservice.domain.model.User;
+import com.pagely.userservice.domain.model.vo.Password;
+import com.pagely.userservice.infrastructure.messaging.event.UserCreatedEvent;
+import com.pagely.userservice.infrastructure.security.BCryptPasswordEncoder;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+class UserEventSerializationTest {
+
+    @Test
+    void userCreatedEvent_직렬화_테스트() throws Exception {
+        // 1. ObjectMapper 설정 (Java 8 날짜 지원)
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // 2. 테스트 데이터 준비 (LocalDateTime 생성 방식 수정)
+        LocalDate birthDate = LocalDate.of(2000, 10, 30);
+        User user = User.create(
+                "alice", "alice@test.com", Password.of("1234567890", new BCryptPasswordEncoder()), "김이박",
+                "이상한나라", "010-2345-6789", Gender.FEMALE, birthDate
+        );
+
+        // 3. 실행
+        UserCreatedEvent event = UserCreatedEvent.from(user);
+        String jsonResult = mapper.writeValueAsString(event);
+
+        // 4. 검증 (단순 출력 대신 assert 사용)
+        System.out.println("Generated JSON: " + jsonResult);
+
+        assertThat(jsonResult).contains("alice@test.com");
+        assertThat(jsonResult).contains("이상한나라");
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 회원가입 완료 시 UserCreatedEvent를 발행.
- UserApplicationService 오류 수정
- MASTER계정 INSERT 추가

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #44   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="2280" height="1348" alt="image" src="https://github.com/user-attachments/assets/25bb424f-5a6c-46c6-8cbc-5397bc85e1e0" />
<img width="760" height="158" alt="image" src="https://github.com/user-attachments/assets/9c75252e-6e9a-4d0a-bba2-dbb2aff67bb5" />

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] `TransactionSynchronizationManager`대신 `ApplicationEventPublisher` + OutBox 방식을 사용했습니다.
https://github.com/Pagely-wisely/user-service/blob/1f9a254617e70f0f9e310e318d71ec0d3485a0ae/src/main/java/com/pagely/userservice/application/service/UserApplicationService.java#L65
- [ ] Flyway 마이그레이션 `V1__init.sql`에 MASTER 계정을 생성하는 insert문을 추가했습니다. (볼륨 재설정 필요)
https://github.com/Pagely-wisely/user-service/blob/81359b03ca45e7b0c801ebf6ba01da31a3810815/src/main/resources/db/migration/V1__init.sql#L68-L83
https://github.com/Pagely-wisely/user-service/blob/81359b03ca45e7b0c801ebf6ba01da31a3810815/src/main/java/com/pagely/userservice/infrastructure/config/FlywayConfig.java#L9-L23 에서`ADMIN_ID`, `ADMIN_PASSWROD`환경변수로 로그인 할 수 있게 Flyway에 주입합니다.

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자 생성 시 이벤트 발행 및 Kafka 연동(아웃박스 기반 저장·폴링 포함)
  * 스케줄링 지원 활성화
  * 관리자 초기 계정 설정 지원

* **Bug Fixes**
  * 가입/프로필 업데이트 시 중복 제약에 따른 명확한 충돌(409) 처리 및 오류 매핑 개선
  * 닉네임 유일성(삭제된 레코드 제외) 보장 강화

* **Chores**
  * 의존성 업데이트 및 Kafka 설정 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->