### PR TITLE
Refactor/55 엔티티 Auditing의 일관성 개선

### DIFF
--- a/src/main/java/com/pagely/userservice/application/service/UserApplicationService.java
+++ b/src/main/java/com/pagely/userservice/application/service/UserApplicationService.java
@@ -52,7 +52,6 @@ public class UserApplicationService {
                 user.getId(),
                 null,
                 user.getNickname(),
-                user.getId(),
                 NicknameChangeReason.CREATE
         );
         // AuditorAware가 신규 유저 본인 ID를 읽어갈 수 있도록 컨텍스트 주입
@@ -83,8 +82,8 @@ public class UserApplicationService {
         String oldNickname = user.getNickname();
         if (command.nickname() != null && !command.nickname().equals(oldNickname)) {
             LocalDateTime lastChangedAt = nicknameHistoryRepository
-                    .findFirstByUserIdOrderByChangedAtDesc(userId)
-                    .map(UserNicknameHistory::getChangedAt)
+                    .findFirstByUserIdOrderByCreatedAtDesc(userId)
+                    .map(UserNicknameHistory::getCreatedAt)
                     .orElse(null);
             validateNickname30Days(lastChangedAt);
 
@@ -92,7 +91,7 @@ public class UserApplicationService {
 
             nicknameHistoryRepository.save(UserNicknameHistory.of(
                     userId, oldNickname, command.nickname(),
-                    userId, NicknameChangeReason.USER_CHANGE
+                    NicknameChangeReason.USER_CHANGE
             ));
         }
 
@@ -130,7 +129,6 @@ public class UserApplicationService {
                             userId,
                             oldNickname,
                             command.nickname(),
-                            currentUserId,
                             NicknameChangeReason.ADMIN_CHANGE
                     )
             );

--- a/src/main/java/com/pagely/userservice/domain/model/UserNicknameHistory.java
+++ b/src/main/java/com/pagely/userservice/domain/model/UserNicknameHistory.java
@@ -2,8 +2,11 @@ package com.pagely.userservice.domain.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -11,14 +14,19 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @Entity
 @Table(name = "p_user_nickname_histories")
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserNicknameHistory {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     @Column(name = "user_id", nullable = false)
@@ -30,11 +38,13 @@ public class UserNicknameHistory {
     @Column(name = "new_nickname", nullable = false, length = 30)
     private String newNickname;
 
-    @Column(name = "changed_at", nullable = false)
-    private LocalDateTime changedAt;
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 
-    @Column(name = "changed_by", nullable = false)
-    private UUID changedBy;
+    @CreatedBy
+    @Column(name = "created_by", nullable = false, updatable = false)
+    private UUID createdBy;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "reason", length = 50)
@@ -44,16 +54,12 @@ public class UserNicknameHistory {
             UUID userId,
             String oldNickname,
             String newNickname,
-            UUID changedBy,
             NicknameChangeReason reason
     ) {
         UserNicknameHistory history = new UserNicknameHistory();
-        history.id = UUID.randomUUID();
         history.userId = userId;
         history.oldNickname = oldNickname;
         history.newNickname = newNickname;
-        history.changedAt = LocalDateTime.now();
-        history.changedBy = changedBy;
         history.reason = reason;
         return history;
     }

--- a/src/main/java/com/pagely/userservice/domain/repository/UserNicknameHistoryRepository.java
+++ b/src/main/java/com/pagely/userservice/domain/repository/UserNicknameHistoryRepository.java
@@ -12,5 +12,5 @@ public interface UserNicknameHistoryRepository {
      * 특정 유저의 가장 최근 닉네임 변경 이력을 조회. 서비스 레이어에서 30일 제한(validateNickname30Days)을 체크할 때 사용합니다.
      * <p>단, 'CREATE', 'USER_CHANGE'와 같이 사용자에 의한 변경 사유만 포함합니다.
      */
-    Optional<UserNicknameHistory> findFirstByUserIdOrderByChangedAtDesc(UUID userId);
+    Optional<UserNicknameHistory> findFirstByUserIdOrderByCreatedAtDesc(UUID userId);
 }

--- a/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxEvent.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxEvent.java
@@ -1,8 +1,10 @@
 package com.pagely.userservice.infrastructure.messaging.outbox;
 
-import com.pagely.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -12,7 +14,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
-import org.springframework.data.domain.Persistable;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Outbox 패턴의 이벤트 저장 엔티티.
@@ -35,10 +38,12 @@ import org.springframework.data.domain.Persistable;
 @Getter
 @Table(name = "p_outbox")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class OutboxEvent extends BaseEntity implements Persistable<UUID> {
+@EntityListeners(AuditingEntityListener.class)
+public class OutboxEvent {
 
     @Id
     @Column(columnDefinition = "UUID")
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     @Column(name = "aggregate_type", nullable = false, length = 50)
@@ -75,6 +80,9 @@ public class OutboxEvent extends BaseEntity implements Persistable<UUID> {
     @Column(name = "last_failure_message", columnDefinition = "TEXT")
     private String lastFailureMessage;
 
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
     // ====================================================================
     // 팩토리 메서드
     // ====================================================================
@@ -106,7 +114,6 @@ public class OutboxEvent extends BaseEntity implements Persistable<UUID> {
         }
 
         OutboxEvent event = new OutboxEvent();
-        event.id = UUID.randomUUID();
         event.aggregateType = aggregateType;
         event.aggregateId = aggregateId;
         event.eventType = eventType;
@@ -146,12 +153,4 @@ public class OutboxEvent extends BaseEntity implements Persistable<UUID> {
         return message.length() > 2000 ? message.substring(0, 2000) : message;
     }
 
-    // ====================================================================
-    // Persistable 구현
-    // ====================================================================
-
-    @Override
-    public boolean isNew() {
-        return getCreatedAt() == null;
-    }
 }

--- a/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxEvent.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxEvent.java
@@ -42,7 +42,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class OutboxEvent {
 
     @Id
-    @Column(columnDefinition = "UUID")
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 

--- a/src/main/java/com/pagely/userservice/infrastructure/persistence/UserNicknameHistoryRepositoryAdapter.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/persistence/UserNicknameHistoryRepositoryAdapter.java
@@ -25,7 +25,7 @@ public class UserNicknameHistoryRepositoryAdapter implements UserNicknameHistory
     }
 
     @Override
-    public Optional<UserNicknameHistory> findFirstByUserIdOrderByChangedAtDesc(UUID userId) {
-        return jpaRepository.findFirstByUserIdAndReasonInOrderByChangedAtDesc(userId, SELF_CHANGE_REASONS);
+    public Optional<UserNicknameHistory> findFirstByUserIdOrderByCreatedAtDesc(UUID userId) {
+        return jpaRepository.findFirstByUserIdAndReasonInOrderByCreatedAtDesc(userId, SELF_CHANGE_REASONS);
     }
 }

--- a/src/main/java/com/pagely/userservice/infrastructure/persistence/jpa/JpaOutboxRepository.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/persistence/jpa/JpaOutboxRepository.java
@@ -24,7 +24,6 @@ public interface JpaOutboxRepository extends JpaRepository<OutboxEvent, UUID> {
     @Query("""
             SELECT e FROM OutboxEvent e
             WHERE e.published = false
-              AND e.deletedAt IS NULL
             ORDER BY e.createdAt ASC
             """)
     List<OutboxEvent> findUnpublished(Pageable pageable);
@@ -36,7 +35,6 @@ public interface JpaOutboxRepository extends JpaRepository<OutboxEvent, UUID> {
             SELECT e FROM OutboxEvent e
             WHERE e.published = false
               AND e.failureCount >= :threshold
-              AND e.deletedAt IS NULL
             ORDER BY e.lastFailureAt DESC
             """)
     List<OutboxEvent> findFailedExceedingThreshold(@Param("threshold") int threshold, Pageable pageable);

--- a/src/main/java/com/pagely/userservice/infrastructure/persistence/jpa/JpaUserNicknameHistoryRepository.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/persistence/jpa/JpaUserNicknameHistoryRepository.java
@@ -11,7 +11,7 @@ public interface JpaUserNicknameHistoryRepository extends JpaRepository<UserNick
     /**
      * 특정 유저의 이력 중 가장 최근(Desc) 1건(First)만 조회
      */
-    Optional<UserNicknameHistory> findFirstByUserIdAndReasonInOrderByChangedAtDesc(UUID userId,
+    Optional<UserNicknameHistory> findFirstByUserIdAndReasonInOrderByCreatedAtDesc(UUID userId,
                                                                                    List<NicknameChangeReason> selfChangeReasons);
 
 }

--- a/src/main/resources/db/migration/V4__standardize_and_simplify_audit_fields.sql
+++ b/src/main/resources/db/migration/V4__standardize_and_simplify_audit_fields.sql
@@ -1,0 +1,33 @@
+-- ============================================================
+-- 1. p_user_nickname_histories 컬럼명 수정
+-- ============================================================
+ALTER TABLE p_user_nickname_histories
+    RENAME COLUMN changed_at TO created_at;
+
+ALTER TABLE p_user_nickname_histories
+    RENAME COLUMN changed_by TO created_by;
+
+COMMENT ON COLUMN p_user_nickname_histories.created_at IS '닉네임 생성/변경 이벤트 발생 시각';
+COMMENT ON COLUMN p_user_nickname_histories.created_by IS '닉네임 생성/변경 이벤트 행위자';
+
+-- ============================================================
+-- 2. p_outbox 에서 의미 약한 audit 컬럼 정리
+-- ============================================================
+ALTER TABLE p_outbox DROP COLUMN created_by;
+ALTER TABLE p_outbox DROP COLUMN updated_at;
+ALTER TABLE p_outbox DROP COLUMN updated_by;
+ALTER TABLE p_outbox DROP COLUMN deleted_at;
+ALTER TABLE p_outbox DROP COLUMN deleted_by;
+
+-- 인덱스 재설정
+DROP INDEX IF EXISTS idx_outbox_unpublished;
+CREATE INDEX idx_outbox_unpublished
+    ON p_outbox (created_at)
+    WHERE published = FALSE;
+
+DROP INDEX IF EXISTS idx_outbox_aggregate;
+CREATE INDEX idx_outbox_aggregate
+    ON p_outbox (aggregate_type, aggregate_id);
+
+-- 코멘트
+COMMENT ON COLUMN p_outbox.created_at IS 'Outbox row 생성 시각';


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 엔티티 Auditing의 일관성 개선
- 유저 서비스 엔티티에 의미 있는 audit 만 두는 원칙을 지키도록 Outbx가 BaseEntity를 상속받게 하지 않게 수정 
- OutboxEvent와 UserNicknamehistory가 User와 동일하게(persistable❌) Auditing 패턴 적용
## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #55  \


## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="789" height="591" alt="image" src="https://github.com/user-attachments/assets/23e6d395-e779-44a5-b305-f24df6157cf0" />

<img width="1140" height="312" alt="image" src="https://github.com/user-attachments/assets/4cf0b1f7-2853-4ac7-804f-613e4deaca28" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.

<img width="554" height="277" alt="image" src="https://github.com/user-attachments/assets/d73902e9-cfc2-489b-9bd3-eecb7059b94c" />

<img width="150" height="66" alt="image" src="https://github.com/user-attachments/assets/27e79fbd-f569-4ba0-a647-2293578708e5" />


<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 닉네임 변경 이력 처리 로직을 최신 생성시점 기준으로 정비해 30일 쿨다운 판정이 더 일관되게 작동합니다.
  * 운영자/사용자 닉네임 변경 이력이 동일한 방식으로 기록되도록 통일했습니다.
  * 아웃박스 이벤트 및 감사 타임스탬프 관련 동작을 간소화하고 일관성 있게 개선했습니다.
* **데이터베이스**
  * 감사 필드 및 인덱스 구조를 표준화하는 마이그레이션을 적용하여 유지보수성을 향상했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->