### PR TITLE
Feat/66 monitoring, kafka 동기 처리를 비동기 방식으로 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxPoller.java
+++ b/src/main/java/com/pagely/userservice/infrastructure/messaging/outbox/OutboxPoller.java
@@ -1,13 +1,13 @@
 package com.pagely.userservice.infrastructure.messaging.outbox;
 
 import java.util.List;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,13 +18,18 @@ import org.springframework.transaction.annotation.Transactional;
  * <p><b>동작</b></p>
  * <ol>
  *   <li>5초마다 미발행 이벤트 BATCH_SIZE 개 조회</li>
- *   <li>Kafka 로 발행</li>
+ *   <li>배치 내 이벤트를 동시에 Kafka 로 발행 (비동기 send)</li>
+ *   <li>모든 발행 결과를 트랜잭션 안에서 확인</li>
  *   <li>성공 → published=true 마킹</li>
  *   <li>실패 → failure_count++, 다음 사이클에서 재시도</li>
  * </ol>
  *
  * <p><b>메시지 키 = aggregate_id (UUID 문자열)</b></p>
- * 같은 entity 의 이벤트는 같은 파티션 → 순서 보장.
+ * 같은 entity 의 이벤트는 같은 파티션으로 라우팅되어 순서가 보장됩니다.
+ *
+ * <p><b>주의</b></p>
+ * PageRequest 는 반드시 {@code org.springframework.data.domain.PageRequest} 를 사용해야 합니다.
+ * 공통 모듈의 PageRequest 는 허용 사이즈(10/30/50)가 제한되어 BATCH_SIZE 가 무시됩니다.
  */
 @Slf4j
 @Component
@@ -41,19 +46,26 @@ public class OutboxPoller {
     @Transactional
     public void publishPendingEvents() {
         List<OutboxEvent> events = outboxRepository.findUnpublished(
-                PageRequest.of(0, BATCH_SIZE)
-        );
-
+                PageRequest.of(0, BATCH_SIZE)); // import 주의! 공통모듈 사용 X
         if (events.isEmpty()) {
             return;
         }
 
         log.debug("Outbox 발행 시작: count={}", events.size());
 
-        for (OutboxEvent event : events) {
+        List<CompletableFuture<SendResult<String, String>>> futures = events.stream()
+                .map(event -> kafkaTemplate.send(
+                        event.getTopic(),
+                        event.getAggregateId().toString(),
+                        event.getPayload()
+                ).toCompletableFuture())
+                .toList();
+
+        for (int i = 0; i < events.size(); i++) {
+            OutboxEvent event = events.get(i);
             try {
-                publishToKafka(event);
-                event.markPublished();
+                futures.get(i).get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                event.markPublished();   // 트랜잭션 안에서 실행 ✅
             } catch (Exception e) {
                 event.recordFailure(e.getMessage());
                 log.error("Outbox 발행 실패: outboxId={}, eventType={}, failureCount={}",
@@ -62,17 +74,5 @@ public class OutboxPoller {
         }
 
         log.debug("Outbox 발행 완료: count={}", events.size());
-    }
-
-    private void publishToKafka(OutboxEvent event) throws ExecutionException, InterruptedException, TimeoutException {
-        String topic = event.getTopic();
-        String messageKey = event.getAggregateId().toString();
-        String payload = event.getPayload();
-
-        // 동기 발행 — 실패 시 즉시 catch 가능 (성능보다 신뢰성 우선)
-        kafkaTemplate.send(topic, messageKey, payload).get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-
-        log.debug("Kafka 발행 성공: topic={}, key={}, eventType={}",
-                topic, messageKey, event.getEventType());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,6 +55,31 @@ eureka:
     fetch-registry: true
     serviceUrl:
       defaultZone: ${EUREKA_SERVER_URL:http://localhost:8000/eureka/}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics, prometheus
+  endpoint:
+    health:
+      show-details: always
+  metrics:
+    tags:
+      application: ${spring.application.name}
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+      percentiles:
+        http.server.requests: 0.5, 0.95, 0.99
+  tracing:
+    sampling:
+      probability: 1.0    # 학습 단계 100% 샘플링. 운영은 0.1 (10%)
+  zipkin:
+    tracing:
+      endpoint: http://${ZIPKIN_HOST:localhost}:9411/api/v2/spans
+
+
 init:
   admin:
     id: ${ADMIN_ID}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,7 @@ spring:
 
 
   kafka: # 이벤트 발행 시 kafka message header에 __TypeId__ 발행을 하지 않고, Json String으로 발행
-    bootstrap-servers: ${KAFKA_EXTERNAL_HOST:localhost}:9092
+    bootstrap-servers: ${KAFKA_EXTERNAL_HOST:localhost}:${KAFKA_EXTERNAL_PORT}
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer #수신 서버에서 ObjectMapper 를 활용하여 수신 서버의 적절한 클래스로 직접 매핑
       #  value-serializer: org.springframework.kafka.support.serializer.JsonSerializer

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,7 @@ spring:
 
 
   kafka: # 이벤트 발행 시 kafka message header에 __TypeId__ 발행을 하지 않고, Json String으로 발행
-    bootstrap-servers: ${KAFKA_EXTERNAL_HOST:localhost:9092}
+    bootstrap-servers: ${KAFKA_EXTERNAL_HOST:localhost}:9092
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer #수신 서버에서 ObjectMapper 를 활용하여 수신 서버의 적절한 클래스로 직접 매핑
       #  value-serializer: org.springframework.kafka.support.serializer.JsonSerializer


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 모니터링 설정
- 기본 application 설정 변수 수정
- Kafka 동기처리 -> 비동기 처리 수정

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #66   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.

[개발 보드 - Kafka 동기처리 vs 비동기 처리 성능 비교 테스트 ](https://www.notion.so/teamsparta/UserService-Kafka-3662dc3ef5148028ba78c060ebe51a71)